### PR TITLE
New rebuilding algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - `EGraph::add_expr` now proceeds linearly through the given `RecExpr`, which
   should be faster and include _all_ e-nodes from the expression.
 - `Rewrite` now has public `searcher` and `applier` fields and no `long_name`.
-- (#61) Rebuilding is much improved!
+- ([#61](https://github.com/egraphs-good/egg/pull/61))
+  Rebuilding is much improved!
   The new algorithm's congruence closure part is closer to
   [Downey, Sethi, Tarjan](https://dl.acm.org/doi/pdf/10.1145/322217.322228),
   and the analysis data propagation is more precise with respect to merging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - `EGraph::add_expr` now proceeds linearly through the given `RecExpr`, which
   should be faster and include _all_ e-nodes from the expression.
 - `Rewrite` now has public `searcher` and `applier` fields and no `long_name`.
+- (#61) Rebuilding is much improved!
+  The new algorithm's congruence closure part is closer to
+  [Downey, Sethi, Tarjan](https://dl.acm.org/doi/pdf/10.1145/322217.322228),
+  and the analysis data propagation is more precise with respect to merging.
+  Overall, the algorithm is simpler, easier to reason about, and more than twice as fast!
 
 ## [0.6.0] - 2020-07-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ rev = "c0b7cb47181e9577a6847caae53a2f0f881f45b2"
 features = ["threadpool"]
 
 [features]
-upward-merging = []
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-1 = [ "serde", "indexmap/serde-1" ]
 reports = [ "serde-1", "serde_json" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,12 @@ harness = false
 [dev-dependencies]
 env_logger = {version = "0.7", default-features = false}
 ordered-float = "1"
-iai = "0.1"
+
+[dev-dependencies.iai]
+# version = "*"
+git = "https://github.com/mwillsey/iai"
+rev = "c0b7cb47181e9577a6847caae53a2f0f881f45b2"
+features = ["threadpool"]
 
 [features]
 upward-merging = []

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ all: test nits bench
 test:
 	cargo build --release
 	cargo test --release
-	cargo test --release --features "upward-merging"
 
 .PHONY: nits
 nits:

--- a/benches/bench_tests.rs
+++ b/benches/bench_tests.rs
@@ -28,7 +28,7 @@ iai::main!(
     math_simplify_root,
     lambda_compose,
     lambda_compose_many,
-    // lambda_fib,
+    lambda_fib,
     // lambda_function_repeat,
     lambda_if,
     lambda_if_elim,

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -574,9 +574,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// // should be equivalent by congruence since x = y.
     /// egraph.union(x, y);
     /// // Classes: [x y] [ax] [ay] [a]
-    /// # #[cfg(not(feature = "upward-merging"))]
     /// assert_eq!(egraph.number_of_classes(), 4);
-    /// # #[cfg(not(feature = "upward-merging"))]
     /// assert_ne!(egraph.find(ax), egraph.find(ay));
     ///
     /// // Rebuilding restores the invariants, finding the "missing" equivalence
@@ -612,7 +610,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             trimmed_nodes,
         );
 
-        // debug_assert!(self.check_memo());
+        debug_assert!(self.check_memo());
         n_unions
     }
 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::{cmp::Ordering, convert::TryFrom};
 use std::fmt::{self, Debug, Display};
 use std::hash::Hash;
 use std::ops::{Index, IndexMut};
@@ -442,8 +442,8 @@ struct ConstantFolding;
 impl Analysis<SimpleMath> for ConstantFolding {
     type Data = Option<i32>;
 
-    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> bool {
-        egg::merge_if_different(to, to.or(from))
+    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> Option<std::cmp::Ordering> {
+        Some(egg::merge_max(to, from))
     }
 
     fn make(egraph: &EGraph<SimpleMath, Self>, enode: &SimpleMath) -> Self::Data {
@@ -504,9 +504,13 @@ pub trait Analysis<L: Language>: Sized {
     fn pre_union(egraph: &EGraph<L, Self>, id1: Id, id2: Id) {}
 
     /// Defines how to merge two `Data`s when their containing
-    /// [`EClass`]es merge. Returns whether `to` is changed.
+    /// [`EClass`]es merge.
     ///
-    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> bool;
+    /// Only called when the two data's are unordered in the lattice.
+    ///
+    /// Default implementation assumes the lattice is totally ordered,
+    /// i.e., it always panics.
+    fn merge(&self, a: &mut Self::Data, b: Self::Data) -> Option<Ordering>;
 
     /// A hook that allows the modification of the
     /// [`EGraph`]
@@ -516,34 +520,28 @@ pub trait Analysis<L: Language>: Sized {
     fn modify(egraph: &mut EGraph<L, Self>, id: Id) {}
 }
 
-/// Replace the first with second value if they are different returning whether
-/// or not something was done.
-///
-/// Useful for implementing
-/// [`Analysis::merge`].
-///
-/// ```
-/// # use egg::*;
-/// let mut x = 6;
-/// assert!(!merge_if_different(&mut x, 6));
-/// assert!(merge_if_different(&mut x, 7));
-/// assert_eq!(x, 7);
-/// ```
-pub fn merge_if_different<D: PartialEq>(to: &mut D, new: D) -> bool {
-    if *to == new {
-        false
-    } else {
-        *to = new;
-        true
-    }
-}
-
 impl<L: Language> Analysis<L> for () {
     type Data = ();
     fn make(_egraph: &EGraph<L, Self>, _enode: &L) -> Self::Data {}
-    fn merge(&self, _to: &mut Self::Data, _from: Self::Data) -> bool {
-        false
+    fn merge(&self, _: &mut Self::Data, _: Self::Data) -> Option<Ordering> {
+        Some(Ordering::Equal)
     }
+}
+
+pub fn merge_max<T: Ord>(to: &mut T, from: T) -> Ordering {
+    let cmp = (*to).cmp(&from);
+    if cmp == Ordering::Less {
+        *to = from;
+    }
+    cmp
+}
+
+pub fn merge_min<T: Ord>(to: &mut T, from: T) -> Ordering {
+    let cmp = (*to).cmp(&from).reverse();
+    if cmp == Ordering::Less {
+        *to = from;
+    }
+    cmp
 }
 
 /// A simple language used for testing.

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -185,8 +185,8 @@ where
 /// struct MinSize;
 /// impl Analysis<Math> for MinSize {
 ///     type Data = usize;
-///     fn merge(&self, to: &mut Self::Data, from: Self::Data) -> bool {
-///         merge_if_different(to, (*to).min(from))
+///     fn merge(&self, to: &mut Self::Data, from: Self::Data) -> Option<std::cmp::Ordering> {
+///         Some(merge_min(to, from))
 ///     }
 ///     fn make(egraph: &EGraph, enode: &Math) -> Self::Data {
 ///         let get_size = |i: Id| egraph[i].data;

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,5 +1,4 @@
 use crate::Id;
-use std::cell::Cell;
 use std::fmt::Debug;
 
 // The Key bound on UnionFind is necessary to derive clone. We only
@@ -8,27 +7,37 @@ use std::fmt::Debug;
 
 #[derive(Debug, Clone, Default)]
 pub struct UnionFind {
-    parents: Vec<Cell<Id>>,
+    parents: Vec<Id>,
 }
 
 impl UnionFind {
     pub fn make_set(&mut self) -> Id {
         let id = Id::from(self.parents.len());
-        self.parents.push(Cell::new(id));
+        self.parents.push(id);
         id
     }
 
     #[inline(always)]
     fn parent(&self, query: Id) -> Id {
-        self.parents[usize::from(query)].get()
+        self.parents[usize::from(query)]
     }
 
     #[inline(always)]
-    fn set_parent(&self, query: Id, new_parent: Id) {
-        self.parents[usize::from(query)].set(new_parent)
+    fn set_parent(&mut self, query: Id, new_parent: Id) {
+        self.parents[usize::from(query)] = new_parent
     }
 
     pub fn find(&self, mut current: Id) -> Id {
+        loop {
+            let parent = self.parent(current);
+            if parent == current {
+                return parent;
+            }
+            current = parent
+        }
+    }
+
+    pub fn find_mut(&mut self, mut current: Id) -> Id {
         loop {
             let parent = self.parent(current);
             if current == parent {
@@ -43,8 +52,8 @@ impl UnionFind {
 
     /// Returns (new_leader, old_leader)
     pub fn union(&mut self, set1: Id, set2: Id) -> (Id, Id) {
-        let mut root1 = self.find(set1);
-        let mut root2 = self.find(set2);
+        let mut root1 = self.find_mut(set1);
+        let mut root2 = self.find_mut(set2);
 
         if root1 == root2 {
             (root1, root2)
@@ -66,12 +75,12 @@ mod tests {
     use indexmap::{indexmap, indexset, IndexMap, IndexSet};
 
     impl UnionFind {
-        pub fn build_sets(&self) -> IndexMap<Id, IndexSet<Id>> {
+        pub fn build_sets(&mut self) -> IndexMap<Id, IndexSet<Id>> {
             let mut map: IndexMap<Id, IndexSet<Id>> = Default::default();
 
             for i in 0..self.parents.len() {
                 let i = Id::from(i);
-                let leader = self.find(i);
+                let leader = self.find_mut(i);
                 map.entry(leader).or_default().insert(i);
             }
 
@@ -100,8 +109,8 @@ mod tests {
         // test the initial condition of everyone in their own set
         for i in 0..n {
             let i = Id::from(i);
-            assert_eq!(uf.find(i), i);
-            assert_eq!(uf.find(i), i);
+            assert_eq!(uf.find_mut(i), i);
+            assert_eq!(uf.find_mut(i), i);
         }
 
         // make sure build_sets works
@@ -135,7 +144,7 @@ mod tests {
 
         // all paths should be compressed at this point
         for i in 0..n {
-            assert_eq!(uf.parent(id(i)), uf.find(id(i)));
+            assert_eq!(uf.parent(id(i)), uf.find_mut(id(i)));
         }
     }
 }

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,9 +1,6 @@
 use crate::Id;
 use std::fmt::Debug;
 
-// The Key bound on UnionFind is necessary to derive clone. We only
-// instantiate UnionFind in one place (EGraph), so this type bound
-// isn't intrusive
 
 #[derive(Debug, Clone, Default)]
 pub struct UnionFind {
@@ -17,134 +14,134 @@ impl UnionFind {
         id
     }
 
+    fn is_root(&self, query: Id) -> bool {
+        query == self.parents[usize::from(query)]
+    }
+
+    // we use unsafe slice accesses internally, but all public Ids
+    // coming in are checked first
     #[inline(always)]
-    fn parent(&self, query: Id) -> Id {
-        self.parents[usize::from(query)]
+    unsafe fn parent(&self, query: Id) -> Id {
+        *self.parents.get_unchecked(usize::from(query))
     }
 
     #[inline(always)]
-    fn set_parent(&mut self, query: Id, new_parent: Id) {
-        self.parents[usize::from(query)] = new_parent
+    unsafe fn parent_mut(&mut self, query: Id) -> &mut Id {
+        self.parents.get_unchecked_mut(usize::from(query))
     }
 
     pub fn find(&self, mut current: Id) -> Id {
-        loop {
-            let parent = self.parent(current);
-            if parent == current {
-                return parent;
+        assert!(usize::from(current) < self.parents.len());
+        unsafe {
+            while current != self.parent(current) {
+                current = self.parent(current)
             }
-            current = parent
         }
+        current
     }
 
     pub fn find_mut(&mut self, mut current: Id) -> Id {
-        loop {
-            let parent = self.parent(current);
-            if current == parent {
-                return parent;
+        assert!(usize::from(current) < self.parents.len());
+        unsafe {
+            while current != self.parent(current) {
+                let grandparent = self.parent(self.parent(current));
+                *self.parent_mut(current) = grandparent;
+                current = grandparent;
             }
-            // do path halving and proceed
-            let grandparent = self.parent(parent);
-            self.set_parent(current, grandparent);
-            current = grandparent;
         }
+        current
     }
 
     /// Returns (new_leader, old_leader)
-    pub fn union(&mut self, set1: Id, set2: Id) -> (Id, Id) {
-        let mut root1 = self.find_mut(set1);
-        let mut root2 = self.find_mut(set2);
+    pub fn union(&mut self, root1: Id, root2: Id) -> (Id, Id) {
+        assert!(self.is_root(root1));
+        assert!(self.is_root(root2));
+        assert_ne!(root1, root2);
 
-        if root1 == root2 {
-            (root1, root2)
-        } else {
-            if root1 > root2 {
-                // NOTE egg actuallly relied on the returned id being the minimum
-                std::mem::swap(&mut root1, &mut root2);
-            }
-            self.set_parent(root2, root1);
-            (root1, root2)
+        unsafe {
+            *self.parent_mut(root2) = root1;
         }
+        (root1, root2)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-    use indexmap::{indexmap, indexset, IndexMap, IndexSet};
+//     use indexmap::{indexmap, indexset, IndexMap, IndexSet};
 
-    impl UnionFind {
-        pub fn build_sets(&mut self) -> IndexMap<Id, IndexSet<Id>> {
-            let mut map: IndexMap<Id, IndexSet<Id>> = Default::default();
+//     impl UnionFind {
+//         pub fn build_sets(&mut self) -> IndexMap<Id, IndexSet<Id>> {
+//             let mut map: IndexMap<Id, IndexSet<Id>> = Default::default();
 
-            for i in 0..self.parents.len() {
-                let i = Id::from(i);
-                let leader = self.find_mut(i);
-                map.entry(leader).or_default().insert(i);
-            }
+//             for i in 0..self.parents.len() {
+//                 let i = Id::from(i);
+//                 let leader = self.find_mut(i);
+//                 map.entry(leader).or_default().insert(i);
+//             }
 
-            map
-        }
-    }
+//             map
+//         }
+//     }
 
-    fn make_union_find(n: usize) -> UnionFind {
-        let mut uf = UnionFind::default();
-        for _ in 0..n {
-            uf.make_set();
-        }
-        uf
-    }
+//     fn make_union_find(n: usize) -> UnionFind {
+//         let mut uf = UnionFind::default();
+//         for _ in 0..n {
+//             uf.make_set();
+//         }
+//         uf
+//     }
 
-    #[test]
-    fn union_find() {
-        let n = 10;
+//     #[test]
+//     fn union_find() {
+//         let n = 10;
 
-        fn id(u: usize) -> Id {
-            u.into()
-        }
+//         fn id(u: usize) -> Id {
+//             u.into()
+//         }
 
-        let mut uf = make_union_find(n);
+//         let mut uf = make_union_find(n);
 
-        // test the initial condition of everyone in their own set
-        for i in 0..n {
-            let i = Id::from(i);
-            assert_eq!(uf.find_mut(i), i);
-            assert_eq!(uf.find_mut(i), i);
-        }
+//         // test the initial condition of everyone in their own set
+//         for i in 0..n {
+//             let i = Id::from(i);
+//             assert_eq!(uf.find_mut(i), i);
+//             assert_eq!(uf.find_mut(i), i);
+//         }
 
-        // make sure build_sets works
-        let expected_sets = (0..n)
-            .map(|i| (id(i), indexset!(id(i))))
-            .collect::<IndexMap<_, _>>();
-        assert_eq!(uf.build_sets(), expected_sets);
+//         // make sure build_sets works
+//         let expected_sets = (0..n)
+//             .map(|i| (id(i), indexset!(id(i))))
+//             .collect::<IndexMap<_, _>>();
+//         assert_eq!(uf.build_sets(), expected_sets);
 
-        // build up one set
-        assert_eq!(uf.union(id(0), id(1)), (id(0), id(1)));
-        assert_eq!(uf.union(id(1), id(2)), (id(0), id(2)));
-        assert_eq!(uf.union(id(3), id(2)), (id(0), id(3)));
+//         // build up one set
+//         assert_eq!(uf.union(id(0), id(1)), (id(0), id(1)));
+//         assert_eq!(uf.union(id(1), id(2)), (id(0), id(2)));
+//         assert_eq!(uf.union(id(3), id(2)), (id(0), id(3)));
 
-        // build up another set
-        assert_eq!(uf.union(id(6), id(7)), (id(6), id(7)));
-        assert_eq!(uf.union(id(8), id(9)), (id(8), id(9)));
-        assert_eq!(uf.union(id(7), id(9)), (id(6), id(8)));
+//         // build up another set
+//         assert_eq!(uf.union(id(6), id(7)), (id(6), id(7)));
+//         assert_eq!(uf.union(id(8), id(9)), (id(8), id(9)));
+//         assert_eq!(uf.union(id(7), id(9)), (id(6), id(8)));
 
-        // make sure union on same set returns to == from
-        assert_eq!(uf.union(id(1), id(3)), (id(0), id(0)));
-        assert_eq!(uf.union(id(7), id(8)), (id(6), id(6)));
+//         // make sure union on same set returns to == from
+//         assert_eq!(uf.union(id(1), id(3)), (id(0), id(0)));
+//         assert_eq!(uf.union(id(7), id(8)), (id(6), id(6)));
 
-        // check set structure
-        let expected_sets = indexmap!(
-            id(0) => indexset!(id(0), id(1), id(2), id(3)),
-            id(4) => indexset!(id(4)),
-            id(5) => indexset!(id(5)),
-            id(6) => indexset!(id(6), id(7), id(8), id(9)),
-        );
-        assert_eq!(uf.build_sets(), expected_sets);
+//         // check set structure
+//         let expected_sets = indexmap!(
+//             id(0) => indexset!(id(0), id(1), id(2), id(3)),
+//             id(4) => indexset!(id(4)),
+//             id(5) => indexset!(id(5)),
+//             id(6) => indexset!(id(6), id(7), id(8), id(9)),
+//         );
+//         assert_eq!(uf.build_sets(), expected_sets);
 
-        // all paths should be compressed at this point
-        for i in 0..n {
-            assert_eq!(uf.parent(id(i)), uf.find_mut(id(i)));
-        }
-    }
-}
+//         // all paths should be compressed at this point
+//         for i in 0..n {
+//             assert_eq!(uf.parent(id(i)), uf.find_mut(id(i)));
+//         }
+//     }
+// }

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,7 +1,6 @@
 use crate::Id;
 use std::fmt::Debug;
 
-
 #[derive(Debug, Clone, Default)]
 pub struct UnionFind {
     parents: Vec<Id>,
@@ -14,134 +13,78 @@ impl UnionFind {
         id
     }
 
-    fn is_root(&self, query: Id) -> bool {
-        query == self.parents[usize::from(query)]
+    fn parent(&self, query: Id) -> Id {
+        self.parents[usize::from(query)]
     }
 
-    // we use unsafe slice accesses internally, but all public Ids
-    // coming in are checked first
-    #[inline(always)]
-    unsafe fn parent(&self, query: Id) -> Id {
-        *self.parents.get_unchecked(usize::from(query))
-    }
-
-    #[inline(always)]
-    unsafe fn parent_mut(&mut self, query: Id) -> &mut Id {
-        self.parents.get_unchecked_mut(usize::from(query))
+    fn parent_mut(&mut self, query: Id) -> &mut Id {
+        &mut self.parents[usize::from(query)]
     }
 
     pub fn find(&self, mut current: Id) -> Id {
-        assert!(usize::from(current) < self.parents.len());
-        unsafe {
-            while current != self.parent(current) {
-                current = self.parent(current)
-            }
+        while current != self.parent(current) {
+            current = self.parent(current)
         }
         current
     }
 
     pub fn find_mut(&mut self, mut current: Id) -> Id {
-        assert!(usize::from(current) < self.parents.len());
-        unsafe {
-            while current != self.parent(current) {
-                let grandparent = self.parent(self.parent(current));
-                *self.parent_mut(current) = grandparent;
-                current = grandparent;
-            }
+        while current != self.parent(current) {
+            let grandparent = self.parent(self.parent(current));
+            *self.parent_mut(current) = grandparent;
+            current = grandparent;
         }
         current
     }
 
     /// Returns (new_leader, old_leader)
-    pub fn union(&mut self, root1: Id, root2: Id) -> (Id, Id) {
-        assert!(self.is_root(root1));
-        assert!(self.is_root(root2));
+    pub fn union(&mut self, root1: Id, root2: Id) -> Id {
+        assert_eq!(root1, self.parent(root1));
+        assert_eq!(root2, self.parent(root2));
         assert_ne!(root1, root2);
-
-        unsafe {
-            *self.parent_mut(root2) = root1;
-        }
-        (root1, root2)
+        *self.parent_mut(root2) = root1;
+        root1
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     use indexmap::{indexmap, indexset, IndexMap, IndexSet};
+    fn ids(us: impl IntoIterator<Item = usize>) -> Vec<Id> {
+        us.into_iter().map(|u| u.into()).collect()
+    }
 
-//     impl UnionFind {
-//         pub fn build_sets(&mut self) -> IndexMap<Id, IndexSet<Id>> {
-//             let mut map: IndexMap<Id, IndexSet<Id>> = Default::default();
+    #[test]
+    fn union_find() {
+        let n = 10;
+        let id = |u: usize| Id::from(u);
 
-//             for i in 0..self.parents.len() {
-//                 let i = Id::from(i);
-//                 let leader = self.find_mut(i);
-//                 map.entry(leader).or_default().insert(i);
-//             }
+        let mut uf = UnionFind::default();
+        for _ in 0..n {
+            uf.make_set();
+        }
 
-//             map
-//         }
-//     }
+        // test the initial condition of everyone in their own set
+        assert_eq!(uf.parents, ids(0..n));
 
-//     fn make_union_find(n: usize) -> UnionFind {
-//         let mut uf = UnionFind::default();
-//         for _ in 0..n {
-//             uf.make_set();
-//         }
-//         uf
-//     }
+        // build up one set
+        uf.union(id(0), id(1));
+        uf.union(id(0), id(2));
+        uf.union(id(0), id(3));
 
-//     #[test]
-//     fn union_find() {
-//         let n = 10;
+        // build up another set
+        uf.union(id(6), id(7));
+        uf.union(id(6), id(8));
+        uf.union(id(6), id(9));
 
-//         fn id(u: usize) -> Id {
-//             u.into()
-//         }
+        // this should compress all paths
+        for i in 0..n {
+            uf.find_mut(id(i));
+        }
 
-//         let mut uf = make_union_find(n);
-
-//         // test the initial condition of everyone in their own set
-//         for i in 0..n {
-//             let i = Id::from(i);
-//             assert_eq!(uf.find_mut(i), i);
-//             assert_eq!(uf.find_mut(i), i);
-//         }
-
-//         // make sure build_sets works
-//         let expected_sets = (0..n)
-//             .map(|i| (id(i), indexset!(id(i))))
-//             .collect::<IndexMap<_, _>>();
-//         assert_eq!(uf.build_sets(), expected_sets);
-
-//         // build up one set
-//         assert_eq!(uf.union(id(0), id(1)), (id(0), id(1)));
-//         assert_eq!(uf.union(id(1), id(2)), (id(0), id(2)));
-//         assert_eq!(uf.union(id(3), id(2)), (id(0), id(3)));
-
-//         // build up another set
-//         assert_eq!(uf.union(id(6), id(7)), (id(6), id(7)));
-//         assert_eq!(uf.union(id(8), id(9)), (id(8), id(9)));
-//         assert_eq!(uf.union(id(7), id(9)), (id(6), id(8)));
-
-//         // make sure union on same set returns to == from
-//         assert_eq!(uf.union(id(1), id(3)), (id(0), id(0)));
-//         assert_eq!(uf.union(id(7), id(8)), (id(6), id(6)));
-
-//         // check set structure
-//         let expected_sets = indexmap!(
-//             id(0) => indexset!(id(0), id(1), id(2), id(3)),
-//             id(4) => indexset!(id(4)),
-//             id(5) => indexset!(id(5)),
-//             id(6) => indexset!(id(6), id(7), id(8), id(9)),
-//         );
-//         assert_eq!(uf.build_sets(), expected_sets);
-
-//         // all paths should be compressed at this point
-//         for i in 0..n {
-//             assert_eq!(uf.parent(id(i)), uf.find_mut(id(i)));
-//         }
-//     }
-// }
+        // indexes:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+        let expected = vec![0, 0, 0, 0, 4, 5, 6, 6, 6, 6];
+        assert_eq!(uf.parents, ids(expected));
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,6 +19,13 @@ pub(crate) type IndexSet<K> = indexmap::IndexSet<K, std::hash::BuildHasherDefaul
 pub(crate) type Instant = instant::Instant;
 pub(crate) type Duration = instant::Duration;
 
+pub(crate) fn concat_vecs<T>(to: &mut Vec<T>, mut from: Vec<T>) {
+    if to.len() < from.len() {
+        std::mem::swap(to, &mut from)
+    }
+    to.extend(from);
+}
+
 static STRINGS: Lazy<Mutex<IndexSet<&'static str>>> = Lazy::new(Default::default);
 
 /// An interned string.

--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -264,7 +264,7 @@ egg::test_fn! {
     lambda_function_repeat, rules(),
     runner = Runner::default()
         .with_time_limit(std::time::Duration::from_secs(20))
-        .with_node_limit(100_000)
+        .with_node_limit(300_000)
         .with_iter_limit(60),
     "(let compose (lam f (lam g (lam x (app (var f)
                                        (app (var g) (var x))))))

--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -262,7 +262,6 @@ egg::test_fn! {
 }
 
 egg::test_fn! {
-    #[cfg_attr(feature = "upward-merging", ignore)]
     lambda_function_repeat, rules(),
     runner = Runner::default()
         .with_time_limit(std::time::Duration::from_secs(20))
@@ -300,7 +299,6 @@ egg::test_fn! {
 }
 
 egg::test_fn! {
-    #[cfg_attr(feature = "upward-merging", ignore)]
     lambda_fib, rules(),
     runner = Runner::default()
         .with_iter_limit(60)

--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -1,5 +1,5 @@
 use egg::{rewrite as rw, *};
-use std::collections::HashSet;
+use std::{cmp::Ordering, collections::HashSet};
 
 define_language! {
     enum Lambda {
@@ -54,16 +54,18 @@ fn eval(egraph: &EGraph, enode: &Lambda) -> Option<Lambda> {
 
 impl Analysis<Lambda> for LambdaAnalysis {
     type Data = Data;
-    fn merge(&self, to: &mut Data, from: Data) -> bool {
+    fn merge(&self, to: &mut Data, from: Data) -> Option<Ordering> {
         let before_len = to.free.len();
         // to.free.extend(from.free);
         to.free.retain(|i| from.free.contains(i));
         let did_change = before_len != to.free.len();
         if to.constant.is_none() && from.constant.is_some() {
             to.constant = from.constant;
-            true
+            None
+        } else if did_change {
+            None
         } else {
-            did_change
+            Some(Ordering::Greater)
         }
     }
 

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -71,12 +71,8 @@ impl Analysis<Math> for ConstantFold {
                 *a = b;
                 Some(Ordering::Less)
             }
-            (Some(_), None) => {
-                Some(Ordering::Greater)
-            }
-            (Some(_), Some(_)) => {
-                Some(Ordering::Equal)
-            }
+            (Some(_), None) => Some(Ordering::Greater),
+            (Some(_), Some(_)) => Some(Ordering::Equal),
         }
         // if a.is_none() && b.is_some() {
         //     *a = b
@@ -101,7 +97,6 @@ impl Analysis<Math> for ConstantFold {
             egraph[id].assert_unique_leaves();
         }
     }
-
 }
 
 fn is_const_or_distinct_var(v: &str, w: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use egg::*;
 
 define_language! {
@@ -18,8 +20,8 @@ type Rewrite = egg::Rewrite<Prop, ConstantFold>;
 struct ConstantFold;
 impl Analysis<Prop> for ConstantFold {
     type Data = Option<bool>;
-    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> bool {
-        merge_if_different(to, to.or(from))
+    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> Option<Ordering> {
+        Some(merge_max(to, from))
     }
     fn make(egraph: &EGraph, enode: &Prop) -> Self::Data {
         let x = |i: &Id| egraph[*i].data;


### PR DESCRIPTION
Rebuilding is much improved! The new algorithm's congruence closure part is closer to [Downey, Sethi, Tarjan](https://dl.acm.org/doi/pdf/10.1145/322217.322228), and the analysis data propagation is more precise with respect to merging.

Overall, the algorithm is simpler, easier to reason about, and more than twice as fast (in the rebuilding phase)!

Here are the overall speedups.
```
name                          cycles       diff
diff_power_harder           22340377 -15.87191%
diff_power_simple            5287483 -10.14223%
integ_one                    1349118 +0.342354%
integ_part1                  8656788 -18.89054%
integ_part2                 32280838 -30.36249%
integ_part3                  3872399 -11.21589%
integ_sin                    1359047 +0.373711%
integ_x                      1425227 -0.319277%
math_associate_adds         63486005 -5.794136%
math_diff_different          1356993 +0.546600%
math_diff_ln                 1370102 +0.353261%
math_diff_same               1339937 +0.613924%
math_diff_simple1            3474429 -7.198271%
math_diff_simple2            3125792 -7.421274%
math_powers                  1467267 -0.285497%
math_simplify_add            2739081 -5.855194%
math_simplify_const          1788490 -4.887436%
math_simplify_factor         8729945 -11.27119%
math_simplify_root          11946627 -11.72115%
lambda_compose               6339816 -8.211156%
lambda_compose_many         23454844 -20.45560%
lambda_fib                2313756186 -0.005102%
lambda_if                    2895215 -7.392474%
lambda_if_elim               1580892 -4.470494%
lambda_if_simple              857032 +0.483404%
lambda_let_simple            1287464 -5.678911%
lambda_under                  988528 +0.109981%
                                     -7.536934% mean
```
