### PR TITLE
Increase rank separation in graphviz output

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -164,6 +164,8 @@ where
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         writeln!(f, "digraph egraph {{")?;
 
+        // Increase space between ranks to improve readability
+        writeln!(f, "  ranksep=2")?;
         // set compound=true to enable edges to clusters
         writeln!(f, "  compound=true")?;
         writeln!(f, "  clusterrank=local")?;


### PR DESCRIPTION
At least in my use cases the graphviz output tends to get very cluttered quickly. I propose to increase the rank separation by default. This will likely not fit all uses cases, I am sure, but at least for me seems to be a good default value for non-trivial cases. Please let me know what you think.