### PR TITLE
Improved e-matching for ground terms

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -257,6 +257,18 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         id.map(|&id| self.find(id))
     }
 
+    /// Lookup the eclass of the given [`RecExpr`].
+    pub fn lookup_expr(&self, expr: &RecExpr<L>) -> Option<Id> {
+        let nodes = expr.as_ref();
+        let mut new_ids = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            let node = node.clone().map_children(|i| new_ids[usize::from(i)]);
+            let id = self.lookup(node)?;
+            new_ids.push(id)
+        }
+        Some(*new_ids.last().unwrap())
+    }
+
     /// Adds an enode to the [`EGraph`].
     ///
     /// When adding an enode, to the egraph, [`add`] it performs

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -26,7 +26,6 @@ enum Instruction<L> {
     Bind { node: L, i: Reg, out: Reg },
     Compare { i: Reg, j: Reg },
     Load { node: L, out: Reg },
-    // Check { node: L, i: Reg },
 }
 
 #[inline(always)]
@@ -208,11 +207,11 @@ impl<'a, L: Language> Compiler<'a, L> {
                     }
                 }
                 ENodeOrVar::ENode(node) => {
-                    // if node.all(|c| is_const[usize::from(c)]) {
-                    //     self.load_term(node, &mut instructions, self.out);
-                    //     instructions.push(Instruction::Compare { i, j: self.out });
-                    //     continue;
-                    // }
+                    if node.all(|c| is_const[usize::from(c)]) {
+                        self.load_term(node, &mut instructions, self.out);
+                        instructions.push(Instruction::Compare { i, j: self.out });
+                        continue;
+                    }
 
                     let out = self.out;
                     self.out.0 += node.len() as u32;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,5 +1,5 @@
 use crate::util::HashSet;
-use crate::{Analysis, EClass, EGraph, ENodeOrVar, Id, Language, PatternAst, Subst, Var};
+use crate::{Analysis, EClass, EGraph, ENodeOrVar, Id, Language, PatternAst, RecExpr, Subst, Var};
 use std::cmp::Ordering;
 
 struct Machine {
@@ -18,6 +18,7 @@ struct Reg(u32);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Program<L> {
     instructions: Vec<Instruction<L>>,
+    ground_terms: Vec<RecExpr<L>>,
     subst: Subst,
 }
 
@@ -25,7 +26,6 @@ pub struct Program<L> {
 enum Instruction<L> {
     Bind { node: L, i: Reg, out: Reg },
     Compare { i: Reg, j: Reg },
-    Load { node: L, out: Reg },
 }
 
 #[inline(always)]
@@ -102,18 +102,6 @@ impl Machine {
                         return;
                     }
                 }
-                Instruction::Load { node, out } => {
-                    let mut iter = self.reg[out.0 as usize..].iter();
-                    let mut node = node.clone();
-                    node.update_children(|_| *iter.next().unwrap());
-                    match egraph.lookup(&mut node) {
-                        Some(id) => {
-                            self.reg.truncate(out.0 as usize);
-                            self.reg.push(id);
-                        }
-                        None => return,
-                    }
-                }
             }
         }
 
@@ -160,7 +148,6 @@ impl<L: Language> Ord for Todo<L> {
 
 struct Compiler<'a, L> {
     pattern: &'a [ENodeOrVar<L>],
-    is_ground: Vec<bool>,
     v2r: VarToReg,
     todo: TodoList<L>,
     out: Reg,
@@ -168,54 +155,26 @@ struct Compiler<'a, L> {
 
 impl<'a, L: Language> Compiler<'a, L> {
     fn compile(pattern: &'a [ENodeOrVar<L>]) -> Program<L> {
-        let mut is_ground: Vec<bool> = vec![false; pattern.len()];
-        for i in 0..pattern.len() {
-            if let ENodeOrVar::ENode(node) = &pattern[i] {
-                is_ground[i] = node.all(|c| is_ground[usize::from(c)]);
-            }
-        }
-        let is_last_ground = is_ground[pattern.len() - 1];
-
-        let last = pattern.last().unwrap();
         let mut compiler = Self {
             pattern,
-            is_ground,
             v2r: Default::default(),
             todo: Default::default(),
-            out: Reg(1),
+            out: Reg(0),
         };
-        compiler.todo.push(Todo {
-            reg: Reg(0),
-            is_ground: is_last_ground,
-            loc: pattern.len() - 1,
-            pat: last.clone(),
-        });
         compiler.go()
     }
 
-    fn load_term(&self, node: L, instructions: &mut Vec<Instruction<L>>, out: Reg) {
-        let mut i = out;
-        node.for_each(|c| {
-            if let ENodeOrVar::ENode(c) = &self.pattern[usize::from(c)] {
-                self.load_term(c.clone(), instructions, i);
-                i.0 += 1
-            }
-        });
-        instructions.push(Instruction::Load { node, out });
-    }
-
-    fn load_ground_locs(&mut self, instructions: &mut Vec<Instruction<L>>) -> Vec<Option<Reg>> {
+    fn get_ground_locs(&mut self, is_ground: &Vec<bool>) -> Vec<Option<Reg>> {
         let mut ground_locs: Vec<Option<Reg>> = vec![None; self.pattern.len()];
         for i in 0..self.pattern.len() {
             if let ENodeOrVar::ENode(node) = &self.pattern[i] {
-                if !self.is_ground[i] {
+                if !is_ground[i] {
                     node.for_each(|c| {
                         let c = usize::from(c);
                         // If a ground pattern is a child of a non-ground pattern,
                         // we load the ground pattern
-                        if self.is_ground[c] && ground_locs[c].is_none() {
-                            if let ENodeOrVar::ENode(node) = &self.pattern[c] {
-                                self.load_term(node.clone(), instructions, self.out);
+                        if is_ground[c] && ground_locs[c].is_none() {
+                            if let ENodeOrVar::ENode(_) = &self.pattern[c] {
                                 ground_locs[c] = Some(self.out);
                                 self.out.0 += 1;
                             } else {
@@ -226,9 +185,8 @@ impl<'a, L: Language> Compiler<'a, L> {
                 }
             }
         }
-        if *self.is_ground.last().unwrap() {
-            if let Some(ENodeOrVar::ENode(node)) = self.pattern.last() {
-                self.load_term(node.clone(), instructions, self.out);
+        if *is_ground.last().unwrap() {
+            if let Some(_) = self.pattern.last() {
                 *ground_locs.last_mut().unwrap() = Some(self.out);
                 self.out.0 += 1;
             } else {
@@ -238,10 +196,46 @@ impl<'a, L: Language> Compiler<'a, L> {
         ground_locs
     }
 
-    fn go(&mut self) -> Program<L> {
-        let mut instructions = vec![];
+    fn build_ground_terms(&self, loc: usize, expr: &mut RecExpr<L>) {
+        if let ENodeOrVar::ENode(mut node) = self.pattern[loc].clone() {
+            node.update_children(|c| {
+                self.build_ground_terms(usize::from(c), expr);
+                (expr.as_ref().len() - 1).into()
+            });
+            expr.add(node);
+        } else {
+            panic!("could only build ground terms");
+        }
+    }
 
-        let ground_locs = self.load_ground_locs(&mut instructions);
+    fn go(&mut self) -> Program<L> {
+        let mut is_ground: Vec<bool> = vec![false; self.pattern.len()];
+        for i in 0..self.pattern.len() {
+            if let ENodeOrVar::ENode(node) = &self.pattern[i] {
+                is_ground[i] = node.all(|c| is_ground[usize::from(c)]);
+            }
+        }
+
+        let ground_locs = self.get_ground_locs(&is_ground);
+        let ground_terms: Vec<RecExpr<L>> = ground_locs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, r)| r.map(|_| i))
+            .map(|i| {
+                let mut expr = Default::default();
+                self.build_ground_terms(i, &mut expr);
+                expr
+            })
+            .collect();
+        self.todo.push(Todo {
+            reg: Reg(self.out.0),
+            is_ground: *is_ground.last().unwrap(),
+            loc: self.pattern.len() - 1,
+            pat: self.pattern.last().unwrap().clone(),
+        });
+        self.out.0 += 1;
+
+        let mut instructions = vec![];
 
         while let Some(Todo {
             reg: i, pat, loc, ..
@@ -269,7 +263,7 @@ impl<'a, L: Language> Compiler<'a, L> {
                         let r = Reg(out.0 + id as u32);
                         self.todo.push(Todo {
                             reg: r,
-                            is_ground: self.is_ground[usize::from(child)],
+                            is_ground: is_ground[usize::from(child)],
                             loc: usize::from(child),
                             pat: self.pattern[usize::from(child)].clone(),
                         });
@@ -287,9 +281,11 @@ impl<'a, L: Language> Compiler<'a, L> {
         for (v, r) in &self.v2r {
             subst.insert(*v, Id::from(r.0 as usize));
         }
+
         Program {
             instructions,
             subst,
+            ground_terms,
         }
     }
 }
@@ -308,7 +304,15 @@ impl<L: Language> Program<L> {
         let mut machine = Machine::default();
 
         assert_eq!(machine.reg.len(), 0);
+        for expr in &self.ground_terms {
+            if let Some(id) = egraph.lookup_expr(&mut expr.clone()) {
+                machine.reg.push(id)
+            } else {
+                return vec![];
+            }
+        }
         machine.reg.push(eclass);
+        println!("{:?}", machine.reg);
 
         let mut substs = Vec::new();
         machine.run(

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -105,15 +105,13 @@ impl Machine {
                 Instruction::Load { node, out } => {
                     let mut iter = self.reg[out.0 as usize..].iter();
                     let mut node = node.clone();
-                    node.update_children(|_| {
-                        *iter.next().unwrap()
-                    });
+                    node.update_children(|_| *iter.next().unwrap());
                     match egraph.lookup(&mut node) {
-                        Some(id) => {        
+                        Some(id) => {
                             self.reg.truncate(out.0 as usize);
                             self.reg.push(id);
                         }
-                        None => return
+                        None => return,
                     }
                 }
             }
@@ -192,7 +190,7 @@ impl<'a, L: Language> Compiler<'a, L> {
         for i in 0..self.pattern.len() {
             is_const[i] = match &self.pattern[i] {
                 ENodeOrVar::Var(_v) => false,
-                ENodeOrVar::ENode(node) => node.all(|c| is_const[usize::from(c)])
+                ENodeOrVar::ENode(node) => node.all(|c| is_const[usize::from(c)]),
             };
         }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -312,7 +312,6 @@ impl<L: Language> Program<L> {
             }
         }
         machine.reg.push(eclass);
-        println!("{:?}", machine.reg);
 
         let mut substs = Vec::new();
         machine.run(

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -229,7 +229,7 @@ impl<'a, L: Language> Compiler<'a, L> {
             .collect();
         self.todo.push(Todo {
             reg: Reg(self.out.0),
-            is_ground: *is_ground.last().unwrap(),
+            is_ground: is_ground[self.pattern.len() - 1],
             loc: self.pattern.len() - 1,
             pat: self.pattern.last().unwrap().clone(),
         });


### PR DESCRIPTION
According to the existing query compilation, every enode will be compiled to a `Bind` operator, which will always add one layer of non-determinism. However, it turns out this is unnecessary.

Consider the example `(+ ?x (+ a b))`, current compilation algorithm will make the program to search for all `+`-app enode `e`, and for each enode in `e.children[1]`, search for the pattern `(+ a b)`. However, because the eclass `(+ a b)` always maps to the same eclass, we can have a simple `Compare` operator to check for eclass equality.

This PR introduces the `Load` operator, which will pop the last `node.len()`-many  Id in the register and push to the register the corresponding enode. Under this compilation algorithm, all ground patterns will be loaded once before the actual e-matching and will be used for comparison. Finally, during compilation, ground patterns are given higher priority and will thus be considered first.

It reduces the run time of the following query from 11.2s (resp. 10.4s) to 9.95ms (resp. 1.12s).
```rust

#[test]
fn math_associate_adds_harder() {
    let rules = &rules();
    let runner: Runner<Math, _> = Runner::default()
        .with_iter_limit(12)
        .with_node_limit(100_000)
        .with_time_limit(std::time::Duration::from_secs(100))
        .with_scheduler(SimpleScheduler)
        .with_expr(
            &"(+ (+ (+ (+ a1 a2) (+ a3 a4)) (+ (+ a5 a6) (+ a7 a8))) (+ (+ a9 a10) (+ a11 a12)))"
            // &"(+ (+ (+ (+ (+ (+ (+ (+ (+ (+ a1 a2) a3) a4) a5) a6) a7) a8) a9) a10) a11)"
                .parse()
                .unwrap(),
        )
        .run(rules);
    runner.print_report();
    let pattern: Pattern<Math> =
        "(+ (+ (+ (+ a1 a2) (+ a3 a4)) (+ (+ a5 a6) (+ a7 a8))) (+ (+ a9 a10) (+ a11 a12)))"
            // "(+ (+ (+ (+ (+ (+ (+ (+ (+ (+ a1 a2) a3) a4) a5) a6) a7) ?z1) ?z) ?y) ?x)"
            .parse()
            .unwrap();
    let start_time = std::time::Instant::now();
    let result = pattern.search(&runner.egraph);
    println!("time elapsed {:?}", std::time::Instant::now() - start_time);
    println!(
        "match size {}",
        result.iter().map(|m| m.substs.len()).sum::<usize>()
    );
}
```