### PR TITLE
Clarify Analysis Data lattice operations

### DIFF
--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -56,47 +56,21 @@ fn eval(egraph: &EGraph, enode: &Lambda) -> Option<Lambda> {
 impl Analysis<Lambda> for LambdaAnalysis {
     type Data = Data;
 
+    fn compare(&self, _: &Self::Data, _: &Self::Data) -> Option<Ordering> {
+        unimplemented!();
+    }
+
+    fn merge(&self, _: Self::Data, _: Self::Data) -> Self::Data {
+        unimplemented!();
+    }
+
     // The data consists of the free variables and constant value.
     // The nodes are unrelated if they have different free variables.
-    fn cmp_data(a: &Self::Data, b: &Self::Data) -> Option<Ordering> {
-        // constant ordering: Constant(X) = true > NonConstant = false
-        let constant_order = a.constant.is_some().cmp(&b.constant.is_some());
-
-        // free ordering: a > b iff b contains a
-        let free_order = if b.free.is_superset(&a.free) {
-            if a.free.len() == b.free.len() {
-                Some(Ordering::Equal)
-            } else {
-                Some(Ordering::Greater)
-            }
-        } else if a.free.is_superset(&b.free) {
-            Some(Ordering::Less)
-        } else {
-            None
-        };
-
-        match (free_order, constant_order) {
-            (Some(Ordering::Equal), y) => Some(y),
-            (Some(x), Ordering::Equal) => Some(x),
-            (Some(Ordering::Less), Ordering::Less) => Some(Ordering::Less),
-            (Some(Ordering::Greater), Ordering::Greater) => Some(Ordering::Greater),
-            _ => None
-        }
-    }
-
-    fn merge_data(a: Self::Data, b: Self::Data) -> Self::Data {
-        let Self::Data { constant, mut free } = a;
-        free.retain(|i| b.free.contains(i));
-        let constant = if constant.is_none() && b.constant.is_some() {
-            b.constant
-        } else {
-            constant
-        };
-
-        Self::Data { constant, free }
-    }
-
-    fn cmp_merge_data(mut a: Self::Data, b: Self::Data) -> (Option<Ordering>, Self::Data) {
+    fn compare_and_merge(
+        &self,
+        mut a: Self::Data,
+        b: Self::Data,
+    ) -> (Option<Ordering>, Self::Data) {
         let before_len = a.free.len();
         // to.free.extend(from.free);
         a.free.retain(|i| b.free.contains(i));

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -65,18 +65,21 @@ impl Analysis<Math> for ConstantFold {
         })
     }
 
-    fn cmp_data(a: &Self::Data, b: &Self::Data) -> Option<Ordering> {
+    fn compare(&self, a: &Self::Data, b: &Self::Data) -> Option<Ordering> {
         let result = match (a, b) {
             (None, None) => Some(Ordering::Equal),
             (None, Some(_)) => Some(Ordering::Less),
             (Some(_), None) => Some(Ordering::Greater),
-            (Some(_), Some(_)) => Some(Ordering::Equal),
+            (Some(x), Some(y)) => {
+                assert_eq!(x, y);
+                Some(Ordering::Equal)
+            }
         };
         result
     }
 
-    fn merge_data(a: Self::Data, b: Self::Data) -> Self::Data {
-        panic!("Unable to merge {:?} and {:?}", a, b)
+    fn merge(&self, _: Self::Data, _: Self::Data) -> Self::Data {
+        unreachable!("Should never merge since comparison is total")
     }
 
     fn modify(egraph: &mut EGraph, id: Id) {

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -18,11 +18,10 @@ type Rewrite = egg::Rewrite<Prop, ConstantFold>;
 
 #[derive(Default)]
 struct ConstantFold;
+
 impl Analysis<Prop> for ConstantFold {
     type Data = Option<bool>;
-    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> Option<Ordering> {
-        Some(merge_max(to, from))
-    }
+
     fn make(egraph: &EGraph, enode: &Prop) -> Self::Data {
         let x = |i: &Id| egraph[*i].data;
         let result = match enode {
@@ -36,6 +35,15 @@ impl Analysis<Prop> for ConstantFold {
         println!("Make: {:?} -> {:?}", enode, result);
         result
     }
+
+    fn cmp_data(a: &Self::Data, b: &Self::Data) -> Option<Ordering> {
+        Some(a.cmp(b))
+    }
+
+    fn merge_data(a: Self::Data, b: Self::Data) -> Self::Data {
+        a.max(b)
+    }
+
     fn modify(egraph: &mut EGraph, id: Id) {
         println!("Modifying {}", id);
         if let Some(c) = egraph[id].data {

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -36,12 +36,12 @@ impl Analysis<Prop> for ConstantFold {
         result
     }
 
-    fn cmp_data(a: &Self::Data, b: &Self::Data) -> Option<Ordering> {
+    fn compare(&self, a: &Self::Data, b: &Self::Data) -> Option<Ordering> {
         Some(a.cmp(b))
     }
 
-    fn merge_data(a: Self::Data, b: Self::Data) -> Self::Data {
-        a.max(b)
+    fn merge(&self, _: Self::Data, _: Self::Data) -> Self::Data {
+        unreachable!("comparison is total")
     }
 
     fn modify(egraph: &mut EGraph, id: Id) {


### PR DESCRIPTION
This introduces two basic lattice operations -- ordering and merging
of `Data` and uses those to describe (and implement) a combined "merge
and return ordering" operation.

The combined operation is what is actually used, allowing for additional
optimizations when it can be simultaneously implemented.