### PR TITLE
Move printing to `Display` and parsing to a new trait, `FromOp`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   [Downey, Sethi, Tarjan](https://dl.acm.org/doi/pdf/10.1145/322217.322228),
   and the analysis data propagation is more precise with respect to merging.
   Overall, the algorithm is simpler, easier to reason about, and more than twice as fast!
+- ([#86](https://github.com/egraphs-good/egg/pull/86))
+  `Language::display_op` and `Language::from_op_str` have been replaced by a new
+  `OpStr` trait. Their rough equivalents are `OpStr::fmt` and `OpStr::from_str`.
+  `define_language!` has been updated to generate `OpStr` implementations, so
+  this change should be mostly transparent to users of the macro.
 
 ## [0.6.0] - 2020-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@
   and the analysis data propagation is more precise with respect to merging.
   Overall, the algorithm is simpler, easier to reason about, and more than twice as fast!
 - ([#86](https://github.com/egraphs-good/egg/pull/86))
-  `Language::display_op` and `Language::from_op_str` have been replaced by a new
-  `OpStr` trait. Their rough equivalents are `OpStr::fmt` and `OpStr::from_str`.
-  `define_language!` has been updated to generate `OpStr` implementations, so
-  this change should be mostly transparent to users of the macro.
+  `Language::display_op` has been removed. Languages should implement `Display`
+  to display the operator instead. `define_language!` now implements `Display`
+  accordingly.
+- `Language::from_op_str` has been replaced by a new `FromOp` trait.
+  `define_language!` implements this trait automatically.
 
 ## [0.6.0] - 2020-07-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 fxhash = "0.2"
 hashbrown = { version = "0.11", default-features = false, features = ["inline-more"] }
+thiserror = "1"
 
 [[bench]]
 name = "bench_tests"

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -11,7 +11,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::io::{Error, ErrorKind, Result, Write};
 use std::path::Path;
 
-use crate::{egraph::EGraph, Analysis, DisplayOp, Language, OpStr};
+use crate::{egraph::EGraph, Analysis, Language};
 
 /**
 A wrapper for an [`EGraph`] that can output [GraphViz] for
@@ -61,15 +61,14 @@ pub struct Dot<'a, L: Language, N: Analysis<L>> {
 
 impl<'a, L, N> Dot<'a, L, N>
 where
-    L: OpStr,
+    L: Language + Display,
     N: Analysis<L>,
 {
     /// Writes the `Dot` to a .dot file with the given filename.
     /// Does _not_ require a `dot` binary.
     pub fn to_dot(&self, filename: impl AsRef<Path>) -> Result<()> {
         let mut file = std::fs::File::create(filename)?;
-        write!(file, "{}", self)?;
-        Ok(())
+        write!(file, "{}", self)
     }
 
     /// Adds a line to the dot output.
@@ -173,13 +172,13 @@ where
 
 impl<'a, L: Language, N: Analysis<L>> Debug for Dot<'a, L, N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Dot({:?})", self.egraph)
+        f.debug_tuple("Dot").field(self.egraph).finish()
     }
 }
 
 impl<'a, L, N> Display for Dot<'a, L, N>
 where
-    L: OpStr,
+    L: Language + Display,
     N: Analysis<L>,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -198,7 +197,7 @@ where
             writeln!(f, "  subgraph cluster_{} {{", class.id)?;
             writeln!(f, "    style=dotted")?;
             for (i, node) in class.iter().enumerate() {
-                writeln!(f, "    {}.{}[label = \"{}\"]", class.id, i, DisplayOp(node))?;
+                writeln!(f, "    {}.{}[label = \"{}\"]", class.id, i, node)?;
             }
             writeln!(f, "  }}")?;
         }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -11,7 +11,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::io::{Error, ErrorKind, Result, Write};
 use std::path::Path;
 
-use crate::{egraph::EGraph, Analysis, Language};
+use crate::{egraph::EGraph, Analysis, DisplayOp, Language, OpStr};
 
 /**
 A wrapper for an [`EGraph`] that can output [GraphViz] for
@@ -61,7 +61,7 @@ pub struct Dot<'a, L: Language, N: Analysis<L>> {
 
 impl<'a, L, N> Dot<'a, L, N>
 where
-    L: Language,
+    L: OpStr,
     N: Analysis<L>,
 {
     /// Writes the `Dot` to a .dot file with the given filename.
@@ -179,7 +179,7 @@ impl<'a, L: Language, N: Analysis<L>> Debug for Dot<'a, L, N> {
 
 impl<'a, L, N> Display for Dot<'a, L, N>
 where
-    L: Language,
+    L: OpStr,
     N: Analysis<L>,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -198,13 +198,7 @@ where
             writeln!(f, "  subgraph cluster_{} {{", class.id)?;
             writeln!(f, "    style=dotted")?;
             for (i, node) in class.iter().enumerate() {
-                writeln!(
-                    f,
-                    "    {}.{}[label = \"{}\"]",
-                    class.id,
-                    i,
-                    node.display_op()
-                )?;
+                writeln!(f, "    {}.{}[label = \"{}\"]", class.id, i, DisplayOp(node))?;
             }
             writeln!(f, "  }}")?;
         }

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -2,7 +2,7 @@ use crate::*;
 use std::{
     borrow::BorrowMut,
     cmp::Ordering,
-    fmt::{self, Debug},
+    fmt::{self, Debug, Display},
 };
 
 use log::*;
@@ -334,26 +334,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         equiv_eclasses
     }
 
-    /// Panic if the given eclass doesn't contain the given patterns
-    ///
-    /// Useful for testing.
-    pub fn check_goals(&self, id: Id, goals: &[Pattern<L>]) {
-        let (cost, best) = Extractor::new(self, AstSize).find_best(id);
-        println!("End ({:?}): {:?}", cost, best);
-
-        for (i, goal) in goals.iter().enumerate() {
-            println!("Trying to prove goal {}: {:?}", i, goal);
-            let matches = goal.search_eclass(&self, id);
-            if matches.is_none() {
-                let best = Extractor::new(&self, AstSize).find_best(id).1;
-                panic!(
-                    "Could not prove goal {}:\n{:?}\nBest thing found:\n{:?}",
-                    i, goal, best,
-                );
-            }
-        }
-    }
-
     /// Unions two eclasses given their ids.
     ///
     /// The given ids need not be canonical.
@@ -420,6 +400,33 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// [`Debug`]: std::fmt::Debug
     pub fn dump(&self) -> impl Debug + '_ {
         EGraphDump(self)
+    }
+}
+
+impl<L: Language + Display, N: Analysis<L>> EGraph<L, N> {
+    /// Panic if the given eclass doesn't contain the given patterns
+    ///
+    /// Useful for testing.
+    pub fn check_goals(&self, id: Id, goals: &[Pattern<L>]) {
+        let (cost, best) = Extractor::new(self, AstSize).find_best(id);
+        println!("End ({}): {}", cost, best.pretty(80));
+
+        for (i, goal) in goals.iter().enumerate() {
+            println!("Trying to prove goal {}: {}", i, goal.pretty(40));
+            let matches = goal.search_eclass(&self, id);
+            if matches.is_none() {
+                let best = Extractor::new(&self, AstSize).find_best(id).1;
+                panic!(
+                    "Could not prove goal {}:\n\
+                     {}\n\
+                     Best thing found:\n\
+                     {}",
+                    i,
+                    goal.pretty(40),
+                    best.pretty(40),
+                );
+            }
+        }
     }
 }
 

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -339,18 +339,16 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Useful for testing.
     pub fn check_goals(&self, id: Id, goals: &[Pattern<L>]) {
         let (cost, best) = Extractor::new(self, AstSize).find_best(id);
-        println!("End ({}): {}", cost, best.pretty(80));
+        println!("End ({:?}): {:?}", cost, best);
 
         for (i, goal) in goals.iter().enumerate() {
-            println!("Trying to prove goal {}: {}", i, goal.pretty(40));
+            println!("Trying to prove goal {}: {:?}", i, goal);
             let matches = goal.search_eclass(&self, id);
             if matches.is_none() {
                 let best = Extractor::new(&self, AstSize).find_best(id).1;
                 panic!(
-                    "Could not prove goal {}:\n{}\nBest thing found:\n{}",
-                    i,
-                    goal.pretty(40),
-                    best.pretty(40),
+                    "Could not prove goal {}:\n{:?}\nBest thing found:\n{:?}",
+                    i, goal, best,
                 );
             }
         }

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,27 +1,27 @@
-use std::fmt::{self, Debug, Display};
 use std::hash::Hash;
 use std::ops::{Index, IndexMut};
 use std::{cmp::Ordering, convert::TryFrom};
+use std::{
+    convert::Infallible,
+    error::Error,
+    fmt::{self, Debug, Display},
+};
 
 use crate::*;
 
-use symbolic_expressions::Sexp;
+use fmt::Formatter;
+use symbolic_expressions::{Sexp, SexpError};
+use thiserror::Error;
 
 /// Trait that defines a Language whose terms will be in the [`EGraph`].
 ///
 /// Check out the [`define_language!`] macro for an easy way to create
 /// a [`Language`].
 ///
-/// Note that the default implementations of
-/// [`from_op_str`](Language::from_op_str()) and
-/// [`display_op`](Language::display_op()) panic. You
-/// should override them if you want to parse or pretty-print expressions.
-/// [`define_language!`] implements these for you.
+/// Note that if you want to parse or pretty-print expressions, you also need to
+/// implement [`OpStr`]. [`define_language!`] implements both traits for you.
 ///
 /// See [`SymbolLang`] for quick-and-dirty use cases.
-///
-/// [`FromStr`]: std::str::FromStr
-/// [`Display`]: std::fmt::Display
 #[allow(clippy::len_without_is_empty)]
 pub trait Language: Debug + Clone + Eq + Ord + Hash {
     /// Returns true if this enode matches another enode.
@@ -42,28 +42,6 @@ pub trait Language: Debug + Clone + Eq + Ord + Hash {
         E: Clone,
     {
         self.fold(Ok(()), |res, id| res.and_then(|_| f(id)))
-    }
-
-    /// Returns something that will print the operator.
-    ///
-    /// Default implementation panics, so make sure to implement this if you
-    /// want to print `Language` elements.
-    /// The [`define_language!`] macro will
-    /// implement this for you.
-    fn display_op(&self) -> &dyn Display {
-        unimplemented!("display_op not implemented")
-    }
-
-    /// Given a string for the operator and the children, tries to make an
-    /// enode.
-    ///
-    /// Default implementation panics, so make sure to implement this if you
-    /// want to parse `Language` elements.
-    /// The [`define_language!`] macro will
-    /// implement this for you.
-    #[allow(unused_variables)]
-    fn from_op_str(op_str: &str, children: Vec<Id>) -> Result<Self, String> {
-        unimplemented!("from_op_str not implemented")
     }
 
     /// Returns the number of the children this enode has.
@@ -145,6 +123,88 @@ pub trait Language: Debug + Clone + Eq + Ord + Hash {
             .map_children(|id| build(&mut expr, child_recexpr(id)));
         expr.add(node);
         expr
+    }
+}
+
+/// A trait for parsing and printing [`Language`]s. This is implemented
+/// automatically when using [`define_language!`].
+///
+/// The [`OpStr::fmt`] and [`OpStr::from_str`] methods should be inverses in the following
+/// sense, where [`DisplayOp`] is a thin wrapper around an [`OpStr`] which uses
+/// [`OpStr::fmt`] as its [`Display`] implementation:
+///
+/// ```
+/// # use egg::*;
+/// fn assert_inverse<T: OpStr>(orig: T) {
+///     let op_string = DisplayOp(&orig).to_string();
+///     let mut children = Vec::new();
+///     orig.for_each(|id| children.push(id));
+///     let parsed = <T as OpStr>::from_str(&op_string, children).unwrap();
+///
+///     assert_eq!(orig, parsed);
+/// }
+/// ```
+///
+/// # Examples
+/// `define_language!` implements `OpStr` automatically:
+/// ```
+/// # use egg::*;
+///
+/// define_language! {
+///     enum Calc {
+///        "+" = Add([Id; 2]),
+///        Num(i32),
+///     }
+/// }
+///
+/// let add = Calc::Add([Id::from(0), Id::from(1)]);
+///
+/// assert_eq!(DisplayOp(&add).to_string(), "+");
+/// assert_eq!(Calc::from_str("+", vec![Id::from(0), Id::from(1)]).unwrap(), add);
+/// ```
+pub trait OpStr: Language {
+    /// The type returned by `from_str` if a string can't be parsed as an
+    /// operator.
+    type Error: Error + 'static;
+
+    /// Format this operator.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result;
+
+    /// Parse an operator string `s` into an e-node with children `children`.
+    fn from_str(s: &str, children: Vec<Id>) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+/// A wrapper for a `Language` whose `Display` implementation forwards to
+/// `OpStr::fmt`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DisplayOp<'a, T: OpStr + 'a>(pub &'a T);
+
+impl<'a, T: OpStr + 'a> Display for DisplayOp<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        <T as OpStr>::fmt(self.0, f)
+    }
+}
+
+/// A generic error for failing to parse an operator. This is the error type
+/// used by `define_language!` for `OpStr::Error`, and is a sensible choice when
+/// implementing `OpStr` manually.
+#[derive(Debug, Error)]
+#[error("failed to parse {op_string:?} as an operator with children {children:?}")]
+pub struct OpParseError {
+    op_string: String,
+    children: Vec<Id>,
+}
+
+impl OpParseError {
+    /// Create a new `OpParseError` indicating that `op_str` couldn't be parsed
+    /// with children `children`.
+    pub fn new(op_str: &str, children: Vec<Id>) -> Self {
+        Self {
+            op_string: op_str.to_owned(),
+            children,
+        }
     }
 }
 
@@ -238,7 +298,7 @@ pub struct RecExpr<L> {
 }
 
 #[cfg(feature = "serde-1")]
-impl<L: Language> serde::Serialize for RecExpr<L> {
+impl<L: OpStr> serde::Serialize for RecExpr<L> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -294,7 +354,7 @@ impl<L: Language> IndexMut<Id> for RecExpr<L> {
     }
 }
 
-impl<L: Language> Display for RecExpr<L> {
+impl<L: OpStr> Display for RecExpr<L> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.nodes.is_empty() {
             write!(f, "()")
@@ -305,10 +365,10 @@ impl<L: Language> Display for RecExpr<L> {
     }
 }
 
-impl<L: Language> RecExpr<L> {
+impl<L: OpStr> RecExpr<L> {
     fn to_sexp(&self, i: usize) -> Sexp {
         let node = &self.nodes[i];
-        let op = Sexp::String(node.display_op().to_string());
+        let op = Sexp::String(DisplayOp(node).to_string());
         if node.is_leaf() {
             op
         } else {
@@ -368,36 +428,67 @@ impl<L: Language> RecExpr<L> {
     }
 }
 
-macro_rules! bail {
-    ($s:literal $(,)?) => {
-        return Err($s.into())
-    };
-    ($s:literal, $($args:expr),+) => {
-        return Err(format!($s, $($args),+).into())
-    };
+/// An error type for failures when attempting to parse an s-expression as a
+/// `RecExpr<L>`.
+#[derive(Debug, Error)]
+pub enum RecExprParseError<L: OpStr> {
+    /// An empty s-expression was found. Usually this is caused by an
+    /// empty list "()" somewhere in the input.
+    #[error("found empty s-expression")]
+    EmptySexp,
+
+    /// A list was found where an operator was expected. This is caused by
+    /// s-expressions of the form "((a b c) d e f)."
+    #[error("found a list in the head position: {0}")]
+    HeadList(Sexp),
+
+    /// Attempting to parse an operator into a value of type `L` failed.
+    #[error("failed to parse operator: {op_string}")]
+    BadOperator {
+        /// The operator.
+        op_string: String,
+
+        /// The resulting error.
+        source: L::Error,
+    },
+
+    /// An error occurred while parsing the s-expression itself, generally
+    /// because the input had an invalid structure (e.g. unpaired parentheses).
+    #[error("failed to parse an s-expression")]
+    BadSexp(#[from] SexpError),
 }
 
-impl<L: Language> std::str::FromStr for RecExpr<L> {
-    type Err = String;
+impl<L: OpStr> std::str::FromStr for RecExpr<L> {
+    type Err = RecExprParseError<L>;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        fn parse_sexp_into<L: Language>(sexp: &Sexp, expr: &mut RecExpr<L>) -> Result<Id, String> {
+        use RecExprParseError::*;
+
+        fn parse_op<L: OpStr>(op_str: &str, children: Vec<Id>) -> Result<L, RecExprParseError<L>> {
+            L::from_str(op_str, children).map_err(|source| BadOperator {
+                op_string: op_str.to_owned(),
+                source,
+            })
+        }
+        fn parse_sexp_into<L: OpStr>(
+            sexp: &Sexp,
+            expr: &mut RecExpr<L>,
+        ) -> Result<Id, RecExprParseError<L>> {
             match sexp {
-                Sexp::Empty => Err("Found empty s-expression".into()),
+                Sexp::Empty => Err(EmptySexp),
                 Sexp::String(s) => {
-                    let node = L::from_op_str(s, vec![])?;
+                    let node = parse_op(s, vec![])?;
                     Ok(expr.add(node))
                 }
-                Sexp::List(list) if list.is_empty() => Err("Found empty s-expression".into()),
+                Sexp::List(list) if list.is_empty() => Err(EmptySexp),
                 Sexp::List(list) => match &list[0] {
                     Sexp::Empty => unreachable!("Cannot be in head position"),
-                    Sexp::List(l) => bail!("Found a list in the head position: {:?}", l),
+                    list @ Sexp::List(..) => Err(HeadList(list.to_owned())),
                     Sexp::String(op) => {
-                        let arg_ids: Result<Vec<Id>, _> =
-                            list[1..].iter().map(|s| parse_sexp_into(s, expr)).collect();
-
-                        let node = L::from_op_str(op, arg_ids?).map_err(|e| {
-                            format!("Failed to parse '{}', error message:\n{}", sexp, e)
-                        })?;
+                        let arg_ids: Vec<Id> = list[1..]
+                            .iter()
+                            .map(|s| parse_sexp_into(s, expr))
+                            .collect::<Result<_, _>>()?;
+                        let node = parse_op(op, arg_ids)?;
                         Ok(expr.add(node))
                     }
                 },
@@ -405,7 +496,7 @@ impl<L: Language> std::str::FromStr for RecExpr<L> {
         }
 
         let mut expr = RecExpr::default();
-        let sexp = symbolic_expressions::parser::parse_str(s.trim()).map_err(|e| e.to_string())?;
+        let sexp = symbolic_expressions::parser::parse_str(s.trim()).map_err(BadSexp)?;
         parse_sexp_into(&sexp, &mut expr)?;
         Ok(expr)
     }
@@ -586,22 +677,26 @@ impl Language for SymbolLang {
         self.op == other.op && self.len() == other.len()
     }
 
-    fn display_op(&self) -> &dyn Display {
-        &self.op
-    }
-
-    fn from_op_str(op_str: &str, children: Vec<Id>) -> Result<Self, String> {
-        Ok(Self {
-            op: op_str.into(),
-            children,
-        })
-    }
-
     fn for_each<F: FnMut(Id)>(&self, f: F) {
         self.children.iter().copied().for_each(f)
     }
 
     fn for_each_mut<F: FnMut(&mut Id)>(&mut self, f: F) {
         self.children.iter_mut().for_each(f)
+    }
+}
+
+impl OpStr for SymbolLang {
+    type Error = Infallible;
+
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.op)
+    }
+
+    fn from_str(s: &str, children: Vec<Id>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            op: s.into(),
+            children,
+        })
     }
 }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -25,7 +25,7 @@ pub struct Rewrite<L, N> {
 
 impl<L, N> fmt::Debug for Rewrite<L, N>
 where
-    L: Language + 'static,
+    L: OpStr + 'static,
     N: 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -406,7 +406,7 @@ where
 ///
 pub struct ConditionEqual<A1, A2>(pub A1, pub A2);
 
-impl<L: Language> ConditionEqual<Pattern<L>, Pattern<L>> {
+impl<L: OpStr> ConditionEqual<Pattern<L>, Pattern<L>> {
     /// Create a ConditionEqual by parsing two pattern strings.
     ///
     /// This panics if the parsing fails.

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Debug, Display};
 use std::{any::Any, sync::Arc};
 
 use crate::*;
@@ -23,9 +23,9 @@ pub struct Rewrite<L, N> {
     pub applier: Arc<dyn Applier<L, N> + Sync + Send>,
 }
 
-impl<L, N> fmt::Debug for Rewrite<L, N>
+impl<L, N> Debug for Rewrite<L, N>
 where
-    L: OpStr + 'static,
+    L: Language + Display + 'static,
     N: 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -406,7 +406,7 @@ where
 ///
 pub struct ConditionEqual<A1, A2>(pub A1, pub A2);
 
-impl<L: OpStr> ConditionEqual<Pattern<L>, Pattern<L>> {
+impl<L: FromOp> ConditionEqual<Pattern<L>, Pattern<L>> {
     /// Create a ConditionEqual by parsing two pattern strings.
     ///
     /// This panics if the parsing fails.

--- a/src/subst.rs
+++ b/src/subst.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::*;
+use fmt::{Debug, Display, Formatter};
 use thiserror::Error;
 
 /// A variable for use in [`Pattern`]s or [`Subst`]s.
@@ -15,7 +16,7 @@ pub struct Var(Symbol);
 
 #[derive(Debug, Error)]
 pub enum VarParseError {
-    #[error("'{0}' doesn't start with '?'")]
+    #[error("pattern variable {0:?} should have a leading question mark")]
     MissingQuestionMark(String),
 }
 
@@ -23,23 +24,25 @@ impl FromStr for Var {
     type Err = VarParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use VarParseError::*;
+
         if s.starts_with('?') && s.len() > 1 {
             Ok(Var(s.into()))
         } else {
-            Err(VarParseError::MissingQuestionMark(s.to_owned()))
+            Err(MissingQuestionMark(s.to_owned()))
         }
     }
 }
 
-impl fmt::Display for Var {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+impl Display for Var {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }
 
-impl fmt::Debug for Var {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+impl Debug for Var {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0, f)
     }
 }
 
@@ -89,8 +92,8 @@ impl std::ops::Index<Var> for Subst {
     }
 }
 
-impl fmt::Debug for Subst {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Debug for Subst {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let len = self.vec.len();
         write!(f, "{{")?;
         for i in 0..len {

--- a/src/subst.rs
+++ b/src/subst.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::*;
+use thiserror::Error;
 
 /// A variable for use in [`Pattern`]s or [`Subst`]s.
 ///
@@ -12,14 +13,20 @@ use crate::*;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Var(Symbol);
 
+#[derive(Debug, Error)]
+pub enum VarParseError {
+    #[error("'{0}' doesn't start with '?'")]
+    MissingQuestionMark(String),
+}
+
 impl FromStr for Var {
-    type Err = String;
+    type Err = VarParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with('?') && s.len() > 1 {
             Ok(Var(s.into()))
         } else {
-            Err(format!("{} doesn't start with '?'", s))
+            Err(VarParseError::MissingQuestionMark(s.to_owned()))
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,6 +3,8 @@
 These are not considered part of the public api.
 */
 
+use std::fmt::Display;
+
 use crate::*;
 
 pub fn env_var<T>(s: &str) -> Option<T>
@@ -32,7 +34,7 @@ pub fn test_runner<L, A>(
     check_fn: Option<fn(Runner<L, A, ()>)>,
     should_check: bool,
 ) where
-    L: Language + 'static,
+    L: Language + Display + 'static,
     A: Analysis<L> + Default,
 {
     let mut runner = runner.unwrap_or_default().with_expr(&start);

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::Mutex;
 
+use fmt::{Debug, Display, Formatter};
 use once_cell::sync::Lazy;
 
 #[allow(unused_imports)]
@@ -98,23 +99,23 @@ impl FromStr for Symbol {
     }
 }
 
-impl fmt::Display for Symbol {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+impl Display for Symbol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self.as_str(), f)
     }
 }
 
-impl fmt::Debug for Symbol {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.as_str())
+impl Debug for Symbol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self.as_str(), f)
     }
 }
 
 /// A wrapper that uses display implementation as debug
 pub(crate) struct DisplayAsDebug<T>(pub T);
 
-impl<T: fmt::Display> fmt::Debug for DisplayAsDebug<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+impl<T: Display> Debug for DisplayAsDebug<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }


### PR DESCRIPTION
This fixes #83 by replacing `Language::display_op` with ~`OpStr::fmt`~ `Display`. It also moves `Language::from_op_str` to ~`OpStr::from_str`~ `FromOp::from_op`. Moving these two functions to a separate trait eliminates the need to give them default implementations which panic. `define_language!` has been updated to automatically implement ~`OpStr`~ `Display` and `FromOp`, so the transition should be seamless for people using the macro.

Additionally, this pull request adds a dependency on [thiserror](https://docs.rs/thiserror/1.0.24/thiserror/), a crate which provides a derive macro for `std::error::Error`, as this refactoring replaces several instances of `String` being used as an error type with structured error types implementing `Error`.

Let me know if there's anything that should be adjusted!