### PR TITLE
Existance Explanations

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -59,7 +59,7 @@ pub struct EGraph<L: Language, N: Analysis<L>> {
     unionfind: UnionFind,
     #[cfg_attr(feature = "serde-1", serde(with = "vectorize"))]
     memo: HashMap<L, Id>,
-    to_union: Vec<(Id, Id, Option<Symbol>)>,
+    to_union: Vec<(Id, Id, Option<Symbol>, bool)>,
     pending: Vec<(L, Id)>,
     analysis_pending: IndexSet<(L, Id)>,
     #[cfg_attr(
@@ -212,6 +212,35 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         }
     }
 
+    /// When explanations are enabled, this function
+    /// produces an [`Explanation`] describing how the given expression came
+    /// to be in the egraph.
+    ///
+    /// The [`Explanation`] begins with some expression that was added directly
+    /// into the egraph and ends with the given `expr`.
+    /// Note that this function can be called again to explain any intermediate terms
+    /// used in the output [`Explanation`].
+    pub fn explain_existance(&mut self, expr: &RecExpr<L>) -> Explanation<L> {
+        if let Some(explain) = &mut self.explain {
+            explain.explain_existance(expr, &self.memo, &mut self.unionfind)
+        } else {
+            panic!("Use runner.with_explanations_enabled() or egraph.with_explanations_enabled() before running to get explanations.")
+        }
+    }
+
+    /// Return an [`Explanation`] for why a pattern appears in the egraph.
+    pub fn explain_existance_pattern(
+        &mut self,
+        pattern: &PatternAst<L>,
+        subst: &Subst,
+    ) -> Explanation<L> {
+        if let Some(explain) = &mut self.explain {
+            explain.explain_existance_pattern(pattern, subst, &self.memo, &mut self.unionfind)
+        } else {
+            panic!("Use runner.with_explanations_enabled() or egraph.with_explanations_enabled() before running to get explanations.")
+        }
+    }
+
     /// Get an explanation for why an expression matches a pattern.
     pub fn explain_matches(
         &mut self,
@@ -304,9 +333,25 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     pub fn add_expr(&mut self, expr: &RecExpr<L>) -> Id {
         let nodes = expr.as_ref();
         let mut new_ids = Vec::with_capacity(nodes.len());
+        let mut new_node_q = Vec::with_capacity(nodes.len());
         for node in nodes {
-            let node = node.clone().map_children(|i| new_ids[usize::from(i)]);
-            new_ids.push(self.add(node))
+            let new_node = node.clone().map_children(|i| new_ids[usize::from(i)]);
+            let size_before = self.unionfind.size();
+            let next_id = self.add(new_node);
+            if self.unionfind.size() > size_before {
+                new_node_q.push(true);
+            } else {
+                new_node_q.push(false);
+            }
+            if let Some(explain) = &mut self.explain {
+                node.for_each(|child| {
+                    // Set the existance reason for new nodes to their parent node.
+                    if new_node_q[usize::from(child)] {
+                        explain.set_existance_reason(new_ids[usize::from(child)], next_id);
+                    }
+                });
+            }
+            new_ids.push(next_id);
         }
         *new_ids.last().unwrap()
     }
@@ -315,15 +360,31 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     pub fn add_instantiation(&mut self, pat: &PatternAst<L>, subst: &Subst) -> Id {
         let nodes = pat.as_ref().as_ref();
         let mut new_ids = Vec::with_capacity(nodes.len());
+        let mut new_node_q = Vec::with_capacity(nodes.len());
         for node in nodes {
             match node {
                 ENodeOrVar::Var(var) => {
                     let id = subst[*var];
                     new_ids.push(id);
+                    new_node_q.push(false);
                 }
                 ENodeOrVar::ENode(node) => {
-                    let node = node.clone().map_children(|i| new_ids[usize::from(i)]);
-                    new_ids.push(self.add(node))
+                    let new_node = node.clone().map_children(|i| new_ids[usize::from(i)]);
+                    let size_before = self.unionfind.size();
+                    let next_id = self.add(new_node);
+                    if self.unionfind.size() > size_before {
+                        new_node_q.push(true);
+                    } else {
+                        new_node_q.push(false);
+                    }
+                    if let Some(explain) = &mut self.explain {
+                        node.for_each(|child| {
+                            if new_node_q[usize::from(child)] {
+                                explain.set_existance_reason(new_ids[usize::from(child)], next_id);
+                            }
+                        });
+                    }
+                    new_ids.push(next_id);
                 }
             }
         }
@@ -394,7 +455,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.lookup(&mut enode).unwrap_or_else(|| {
             let id = self.unionfind.make_set();
             if let Some(explain) = &mut self.explain {
-                explain.add(enode.clone(), id);
+                explain.add(enode.clone(), id, id);
             }
             log::trace!("  ...adding to {}", id);
             let class = EClass {
@@ -465,10 +526,12 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         rule_name: impl Into<Symbol>,
     ) -> (Id, bool) {
         let id1 = self.add_instantiation(from_pat, subst);
+        let size_before = self.unionfind.size();
         let id2 = self.add_instantiation(to_pat, subst);
+        let rhs_new = self.unionfind.size() > size_before;
         (
             id1,
-            self.union_with_justification(id1, id2, from_pat, to_pat, subst, rule_name),
+            self.union_with_justification(id1, id2, from_pat, to_pat, subst, rule_name, rhs_new),
         )
     }
 
@@ -480,6 +543,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         to_pat: &PatternAst<L>,
         subst: &Subst,
         rule_name: impl Into<Symbol>,
+        rhs_new: bool,
     ) -> bool {
         self.clean = false;
         if let Some(explain) = &mut self.explain {
@@ -488,9 +552,11 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             } else {
                 let left_added =
                     explain.add_match(from_pat, subst, &self.memo, &mut self.unionfind);
+                let size_before_right = self.unionfind.size();
                 let right_added = explain.add_match(to_pat, subst, &self.memo, &mut self.unionfind);
+                let any_new_rhs = rhs_new || self.unionfind.size() > size_before_right;
                 self.to_union
-                    .push((left_added, right_added, Some(rule_name.into())));
+                    .push((left_added, right_added, Some(rule_name.into()), any_new_rhs));
                 true
             }
         } else {
@@ -523,12 +589,18 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         if self.find_mut(id1) == self.find_mut(id2) {
             false
         } else {
-            self.to_union.push((id1, id2, None));
+            self.to_union.push((id1, id2, None, false));
             true
         }
     }
 
-    fn perform_union(&mut self, enode_id1: Id, enode_id2: Id, rule: Option<Justification>) -> bool {
+    fn perform_union(
+        &mut self,
+        enode_id1: Id,
+        enode_id2: Id,
+        rule: Option<Justification>,
+        any_new_rhs: bool,
+    ) -> bool {
         let mut id1 = self.find_mut(enode_id1);
         let mut id2 = self.find_mut(enode_id2);
         if id1 == id2 {
@@ -544,7 +616,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         N::pre_union(self, id1, id2);
 
         if let Some(explain) = &mut self.explain {
-            explain.union(enode_id1, enode_id2, rule.unwrap());
+            explain.union(enode_id1, enode_id2, rule.unwrap(), any_new_rhs);
         } else {
             assert!(rule.is_none());
         }
@@ -703,8 +775,8 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         while !self.to_union.is_empty() {
             let mut current = vec![];
             std::mem::swap(&mut self.to_union, &mut current);
-            for (id1, id2, rule) in current.into_iter() {
-                self.perform_union(id1, id2, rule.map(Justification::Rule));
+            for (id1, id2, rule, any_new_rhs) in current.into_iter() {
+                self.perform_union(id1, id2, rule.map(Justification::Rule), any_new_rhs);
             }
         }
     }
@@ -728,7 +800,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                         if self.explain.is_some() {
                             reason = Some(Justification::Congruence);
                         }
-                        let did_something = self.perform_union(memo_class, class, reason);
+                        let did_something = self.perform_union(memo_class, class, reason, false);
                         n_unions += did_something as usize;
                     }
                 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -22,6 +22,12 @@ struct ExplainNode<L: Language> {
     next: Id,
     current: Id,
     justification: Justification,
+    // it was inserted because of:
+    // 1) it's parent is inserted (points to parent enode)
+    // 2) a rewrite instantiated it (points to adjacent enode)
+    // 3) it was inserted directly (points to itself)
+    // if 1 is true but it's also adjacent (2) then either works and it picks 2
+    existance_node: Id,
     is_rewrite_forward: bool,
 }
 
@@ -752,6 +758,22 @@ impl<L: Language> Explain<L> {
         let rule_table = Explain::make_rule_table(rules);
         for i in 0..self.explainfind.len() {
             let explain_node = &self.explainfind[i];
+
+            // check that explanation reasons never form a cycle
+            let mut existance = i;
+            let mut seen_existance: HashSet<usize> = Default::default();
+            loop {
+                seen_existance.insert(existance);
+                let next = usize::from(self.explainfind[existance].existance_node);
+                if existance == next {
+                    break;
+                }
+                existance = next;
+                if seen_existance.contains(&existance) {
+                    assert!(false, "Cycle in existance!");
+                }
+            }
+
             if explain_node.next != Id::from(i) {
                 let mut current_explanation = self.node_to_flat_explanation(Id::from(i));
                 let mut next_explanation = self.node_to_flat_explanation(explain_node.next);
@@ -781,13 +803,18 @@ impl<L: Language> Explain<L> {
         }
     }
 
-    pub fn add(&mut self, node: L, set: Id) -> Id {
+    pub(crate) fn set_existance_reason(&mut self, node: Id, existance_node: Id) {
+        self.explainfind[usize::from(node)].existance_node = existance_node;
+    }
+
+    pub(crate) fn add(&mut self, node: L, set: Id, existance_node: Id) -> Id {
         self.uncanon_memo.insert(node.clone(), set);
         self.explainfind.push(ExplainNode {
             node,
             justification: Justification::Congruence,
             next: set,
             current: set,
+            existance_node,
             is_rewrite_forward: false,
         });
         set
@@ -853,11 +880,18 @@ impl<L: Language> Explain<L> {
                                 .map_children(|id| unionfind.find(id))
                         );
 
-                        let new_congruent_id = self.add(new_congruent_node, unionfind.make_set());
+                        let new_congruent_id =
+                            self.add(new_congruent_node, unionfind.make_set(), congruent_id);
+
                         match_ids.push(new_congruent_id);
                         // make the congruent_id we found the leader
                         unionfind.union(congruent_class, new_congruent_id);
-                        self.union(new_congruent_id, congruent_id, Justification::Congruence);
+                        self.union(
+                            new_congruent_id,
+                            congruent_id,
+                            Justification::Congruence,
+                            false,
+                        );
                     }
                 }
             }
@@ -880,7 +914,17 @@ impl<L: Language> Explain<L> {
         }
     }
 
-    pub(crate) fn union(&mut self, node1: Id, node2: Id, justification: Justification) {
+    pub(crate) fn union(
+        &mut self,
+        node1: Id,
+        node2: Id,
+        justification: Justification,
+        new_rhs: bool,
+    ) {
+        if new_rhs {
+            self.set_existance_reason(node2, node1)
+        }
+
         self.make_leader(node1);
         self.explainfind[usize::from(node1)].next = node2;
         self.explainfind[usize::from(node1)].justification = justification;
@@ -912,6 +956,37 @@ impl<L: Language> Explain<L> {
         let right_added = self.add_expr(right, memo, unionfind);
         let mut cache = Default::default();
         Explanation::new(self.explain_enodes(left_added, right_added, &mut cache))
+    }
+
+    pub(crate) fn explain_existance(
+        &mut self,
+        left: &RecExpr<L>,
+        memo: &HashMap<L, Id>,
+        unionfind: &mut UnionFind,
+    ) -> Explanation<L> {
+        let left_added = self.add_expr(left, memo, unionfind);
+        let mut cache = Default::default();
+        Explanation::new(self.explain_enode_existance(
+            left_added,
+            Rc::new(self.node_to_explanation(left_added)),
+            &mut cache,
+        ))
+    }
+
+    pub(crate) fn explain_existance_pattern(
+        &mut self,
+        left: &PatternAst<L>,
+        subst: &Subst,
+        memo: &HashMap<L, Id>,
+        unionfind: &mut UnionFind,
+    ) -> Explanation<L> {
+        let left_added = self.add_match(left, &subst, memo, unionfind);
+        let mut cache = Default::default();
+        Explanation::new(self.explain_enode_existance(
+            left_added,
+            Rc::new(self.node_to_explanation(left_added)),
+            &mut cache,
+        ))
     }
 
     fn common_ancestor(&self, mut left: Id, mut right: Id) -> Id {
@@ -951,6 +1026,58 @@ impl<L: Language> Explain<L> {
             assert!(next != node);
             node = next;
         }
+    }
+
+    fn explain_enode_existance(
+        &self,
+        node: Id,
+        rest_of_proof: Rc<TreeTerm<L>>,
+        cache: &mut ExplainCache<L>,
+    ) -> TreeExplanation<L> {
+        let graphnode = &self.explainfind[usize::from(node)];
+        let existance = graphnode.existance_node;
+        let existance_node = &self.explainfind[usize::from(existance)];
+        // case 1)
+        if existance == node {
+            return vec![Rc::new(self.node_to_explanation(node)), rest_of_proof];
+        }
+
+        // case 2)
+        if graphnode.next == existance || existance_node.next == node {
+            let direction;
+            let justification;
+            if graphnode.next == existance {
+                direction = !graphnode.is_rewrite_forward;
+                justification = &graphnode.justification;
+            } else {
+                direction = existance_node.is_rewrite_forward;
+                justification = &existance_node.justification;
+            }
+            return self.explain_enode_existance(
+                existance,
+                self.explain_adjacent(existance, node, direction, justification, cache),
+                cache,
+            );
+        }
+
+        // case 3)
+        let mut new_rest_of_proof = self.node_to_explanation(existance);
+        let mut index_of_child = 0;
+        let mut found = false;
+        existance_node.node.for_each(|child| {
+            if found {
+                return;
+            }
+            if child == node {
+                found = true;
+            } else {
+                index_of_child += 1;
+            }
+        });
+        assert!(found);
+        new_rest_of_proof.child_proofs[index_of_child].push(rest_of_proof);
+
+        self.explain_enode_existance(existance, Rc::new(new_rest_of_proof), cache)
     }
 
     fn explain_enodes(

--- a/src/run.rs
+++ b/src/run.rs
@@ -406,6 +406,20 @@ where
         self.egraph.explain_equivalence(left, right)
     }
 
+    /// Calls [`EGraph::explain_existance`](EGraph::explain_existance()).
+    pub fn explain_existance(&mut self, expr: &RecExpr<L>) -> Explanation<L> {
+        self.egraph.explain_existance(expr)
+    }
+
+    /// Calls [EGraph::explain_existance_pattern`](EGraph::explain_existance_pattern()).
+    pub fn explain_existance_pattern(
+        &mut self,
+        pattern: &PatternAst<L>,
+        subst: &Subst,
+    ) -> Explanation<L> {
+        self.egraph.explain_existance_pattern(pattern, subst)
+    }
+
     /// Get an explanation for why an expression matches a pattern.
     pub fn explain_matches(
         &mut self,

--- a/src/test.rs
+++ b/src/test.rs
@@ -95,6 +95,11 @@ pub fn test_runner<L, A>(
                 explained.get_sexp_with_let();
                 explained.get_flat_sexps();
                 explained.check_proof(rules);
+
+                let mut existance = runner.explain_existance_pattern(&goal.ast, &subst);
+                existance.get_sexp_with_let();
+                existance.get_flat_sexps();
+                existance.check_proof(rules);
             }
         }
 

--- a/src/tutorials/_03_explanations.rs
+++ b/src/tutorials/_03_explanations.rs
@@ -60,10 +60,9 @@ In fact, normally the rules `times-zero` and `cancel-denominator` are perfectly
   reasonable.
 However, in the presence of a division by zero, they lead to arbitrary unions in the egraph.
 So the true problem is the presense of the term `(/ 1 0)`.
-For these kinds of questions, `egg` provides the TODO function which can be used to get an explanation
+For these kinds of questions, `egg` provides the `explain_existance` function which can be used to get an explanation
   of why a term exists in the egraph in the first place.
 
-TODO implement the existance explanation function
 
 # Explanation Trees
 

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -14,6 +14,10 @@ impl UnionFind {
         id
     }
 
+    pub fn size(&self) -> usize {
+        self.parents.len()
+    }
+
     fn parent(&self, query: Id) -> Id {
         self.parents[usize::from(query)]
     }


### PR DESCRIPTION
Sometimes, it's unclear why an expression is represented in the egraph in the first place. In fact, these "magic terms" can sometimes be critical in finding an equality. Consider:
```
0
(Rewrite<= times-zero (* (/ 1 0) 0))
(Rewrite=> cancel-denominator 1)
```

`(* (/ 1 0) 0))` is a magic term, and we would like a proof of how it got to be in the egraph in the first place. I call these existence explanations, and this PR implements them. Whenever a term is added to the egraph, the `Explain` keeps track of where it came from. This could be either from a rule application, from a parent being inserted, or from congruence. Existance explanations simply follow the chain of pointers back to an original term manually added to the egraph.