### PR TITLE
Instant Unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- ([#165](https://github.com/egraphs-good/egg/pull/165)) Unions now happen "instantly", restoring the pre-0.7 behavior. 
+
 ## [0.7.1] - 2021-12-14
 
 This patch fixes a pretty bad e-matching bug introduced in 0.7.0. Please upgrade!

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -59,7 +59,6 @@ pub struct EGraph<L: Language, N: Analysis<L>> {
     unionfind: UnionFind,
     #[cfg_attr(feature = "serde-1", serde(with = "vectorize"))]
     memo: HashMap<L, Id>,
-    to_union: Vec<(Id, Id, Option<Symbol>, bool)>,
     pending: Vec<(L, Id)>,
     analysis_pending: IndexSet<(L, Id)>,
     #[cfg_attr(
@@ -108,7 +107,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     pub fn new(analysis: N) -> Self {
         Self {
             analysis,
-            to_union: Default::default(),
             classes: Default::default(),
             unionfind: Default::default(),
             clean: false,
@@ -205,8 +203,10 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// flattened form. Each of these also has a s-expression string representation,
     /// given by [`get_flat_string`](Explanation::get_flat_string) and [`get_string`](Explanation::get_string).
     pub fn explain_equivalence(&mut self, left: &RecExpr<L>, right: &RecExpr<L>) -> Explanation<L> {
+        let left = self.add_expr_internal(left);
+        let right = self.add_expr_internal(right);
         if let Some(explain) = &mut self.explain {
-            explain.explain_equivalence(left, right, &self.memo, &mut self.unionfind)
+            explain.explain_equivalence(left, right)
         } else {
             panic!("Use runner.with_explanations_enabled() or egraph.with_explanations_enabled() before running to get explanations.")
         }
@@ -221,8 +221,9 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Note that this function can be called again to explain any intermediate terms
     /// used in the output [`Explanation`].
     pub fn explain_existance(&mut self, expr: &RecExpr<L>) -> Explanation<L> {
+        let id = self.add_expr_internal(expr);
         if let Some(explain) = &mut self.explain {
-            explain.explain_existance(expr, &self.memo, &mut self.unionfind)
+            explain.explain_existance(id)
         } else {
             panic!("Use runner.with_explanations_enabled() or egraph.with_explanations_enabled() before running to get explanations.")
         }
@@ -234,8 +235,9 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         pattern: &PatternAst<L>,
         subst: &Subst,
     ) -> Explanation<L> {
+        let id = self.add_instantiation_internal(pattern, subst);
         if let Some(explain) = &mut self.explain {
-            explain.explain_existance_pattern(pattern, subst, &self.memo, &mut self.unionfind)
+            explain.explain_existance(id)
         } else {
             panic!("Use runner.with_explanations_enabled() or egraph.with_explanations_enabled() before running to get explanations.")
         }
@@ -248,8 +250,10 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         right: &PatternAst<L>,
         subst: &Subst,
     ) -> Explanation<L> {
+        let left = self.add_expr_internal(left);
+        let right = self.add_instantiation_internal(right, subst);
         if let Some(explain) = &mut self.explain {
-            explain.explain_matches(left, right, subst, &self.memo, &mut self.unionfind)
+            explain.explain_equivalence(left, right)
         } else {
             panic!("Use runner.with_explanations_enabled() or egraph.with_explanations_enabled() before running to get explanations.");
         }
@@ -316,7 +320,7 @@ impl<L: Language, N: Analysis<L>> std::ops::IndexMut<Id> for EGraph<L, N> {
 }
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
-    /// Adds a [`RecExpr`] to the [`EGraph`].
+    /// Adds a [`RecExpr`] to the [`EGraph`], returning the id of the RecExpr's eclass.
     ///
     /// # Example
     /// ```
@@ -331,13 +335,19 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     ///
     /// [`add_expr`]: EGraph::add_expr()
     pub fn add_expr(&mut self, expr: &RecExpr<L>) -> Id {
+        let id = self.add_expr_internal(expr);
+        self.find(id)
+    }
+
+    /// Adds an expr to the egraph, and returns the uncanonicalized id of the top enode.
+    fn add_expr_internal(&mut self, expr: &RecExpr<L>) -> Id {
         let nodes = expr.as_ref();
         let mut new_ids = Vec::with_capacity(nodes.len());
         let mut new_node_q = Vec::with_capacity(nodes.len());
         for node in nodes {
             let new_node = node.clone().map_children(|i| new_ids[usize::from(i)]);
             let size_before = self.unionfind.size();
-            let next_id = self.add(new_node);
+            let next_id = self.add_internal(new_node);
             if self.unionfind.size() > size_before {
                 new_node_q.push(true);
             } else {
@@ -356,8 +366,14 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         *new_ids.last().unwrap()
     }
 
-    /// Adds a [`Pattern`] and a substitution to the [`EGraph`].
+    /// Adds a [`Pattern`] and a substitution to the [`EGraph`], returning
+    /// the eclass of the instantiated pattern.
     pub fn add_instantiation(&mut self, pat: &PatternAst<L>, subst: &Subst) -> Id {
+        let id = self.add_instantiation_internal(pat, subst);
+        self.find(id)
+    }
+
+    fn add_instantiation_internal(&mut self, pat: &PatternAst<L>, subst: &Subst) -> Id {
         let nodes = pat.as_ref().as_ref();
         let mut new_ids = Vec::with_capacity(nodes.len());
         let mut new_node_q = Vec::with_capacity(nodes.len());
@@ -371,7 +387,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                 ENodeOrVar::ENode(node) => {
                     let new_node = node.clone().map_children(|i| new_ids[usize::from(i)]);
                     let size_before = self.unionfind.size();
-                    let next_id = self.add(new_node);
+                    let next_id = self.add_internal(new_node);
                     if self.unionfind.size() > size_before {
                         new_node_q.push(true);
                     } else {
@@ -459,37 +475,64 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// so you must call [`rebuild`](EGraph::rebuild) any query operations.
     ///
     /// [`add`]: EGraph::add()
-    pub fn add(&mut self, mut enode: L) -> Id {
-        self.lookup(&mut enode).unwrap_or_else(|| {
-            let id = self.unionfind.make_set();
-            if let Some(explain) = &mut self.explain {
-                explain.add(enode.clone(), id, id);
+    pub fn add(&mut self, enode: L) -> Id {
+        let id = self.add_internal(enode);
+        self.find(id)
+    }
+
+    /// Adds an enode to the egraph and also returns the the enode's id (uncanonicalized).
+    fn add_internal(&mut self, mut enode: L) -> Id {
+        let original = enode.clone();
+        if let Some(id) = self.lookup(&mut enode) {
+            // when explanations are enabled, we need a new representative for this expr
+            if let Some(explain) = self.explain.as_mut() {
+                if !explain.uncanon_memo.contains_key(&original) {
+                    let new_id = self.unionfind.make_set();
+                    explain.add(original.clone(), new_id, new_id);
+                    self.unionfind.union(id, new_id);
+                    explain.union(id, new_id, Justification::Congruence, true);
+                    return new_id;
+                }
             }
-            log::trace!("  ...adding to {}", id);
-            let class = EClass {
-                id,
-                nodes: vec![enode.clone()],
-                data: N::make(self, &enode),
-                parents: Default::default(),
-            };
 
-            // add this enode to the parent lists of its children
-            enode.for_each(|child| {
-                let tup = (enode.clone(), id);
-                self[child].parents.push(tup);
-            });
+            id
+        } else {
+            let id = self.make_new_eclass(enode);
+            if let Some(explain) = self.explain.as_mut() {
+                explain.add(original.clone(), id, id);
+            }
 
-            // TODO is this needed?
-            self.pending.push((enode.clone(), id));
-
-            self.classes.insert(id, class);
-            assert!(self.memo.insert(enode, id).is_none());
-
+            // now that we updated explanations, run the analysis for the new eclass
             N::modify(self, id);
-
             self.clean = false;
             id
-        })
+        }
+    }
+
+    /// This function makes a new eclass in the egraph (but doesn't touch explanations)
+    fn make_new_eclass(&mut self, enode: L) -> Id {
+        let id = self.unionfind.make_set();
+        log::trace!("  ...adding to {}", id);
+        let class = EClass {
+            id,
+            nodes: vec![enode.clone()],
+            data: N::make(self, &enode),
+            parents: Default::default(),
+        };
+
+        // add this enode to the parent lists of its children
+        enode.for_each(|child| {
+            let tup = (enode.clone(), id);
+            self[child].parents.push(tup);
+        });
+
+        // TODO is this needed?
+        self.pending.push((enode.clone(), id));
+
+        self.classes.insert(id, class);
+        assert!(self.memo.insert(enode, id).is_none());
+
+        id
     }
 
     /// Checks whether two [`RecExpr`]s are equivalent.
@@ -519,13 +562,13 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     /// Given two patterns and a substitution, add the patterns
-    /// and mark them for unioning.
-    /// The unions are performed when [`rebuild`](EGraph::rebuild) is called.
+    /// and union them.
+    ///
     /// When explanations are enabled [`with_explanations_enabled`](Runner::with_explanations_enabled), use
     /// this function instead of [`union`](EGraph::union).
     ///
-    /// The returned `bool` indicates whether a union is necessary,
-    /// and returned Id represents the eclass of the left pattern.
+    /// Returns the id of the new eclass, along with
+    /// a `bool` indicating whether a union occured.
     pub fn union_instantiations(
         &mut self,
         from_pat: &PatternAst<L>,
@@ -533,50 +576,21 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         subst: &Subst,
         rule_name: impl Into<Symbol>,
     ) -> (Id, bool) {
-        let id1 = self.add_instantiation(from_pat, subst);
+        let id1 = self.add_instantiation_internal(from_pat, subst);
         let size_before = self.unionfind.size();
-        let id2 = self.add_instantiation(to_pat, subst);
+        let id2 = self.add_instantiation_internal(to_pat, subst);
         let rhs_new = self.unionfind.size() > size_before;
-        (
+
+        let did_union = self.perform_union(
             id1,
-            self.union_with_justification(id1, id2, from_pat, to_pat, subst, rule_name, rhs_new),
-        )
+            id2,
+            Some(Justification::Rule(rule_name.into())),
+            rhs_new,
+        );
+        (self.find(id1), did_union)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn union_with_justification(
-        &mut self,
-        id1: Id,
-        id2: Id,
-        from_pat: &PatternAst<L>,
-        to_pat: &PatternAst<L>,
-        subst: &Subst,
-        rule_name: impl Into<Symbol>,
-        rhs_new: bool,
-    ) -> bool {
-        self.clean = false;
-        if let Some(explain) = &mut self.explain {
-            if self.unionfind.find_mut(id1) == self.unionfind.find_mut(id2) {
-                false
-            } else {
-                let left_added =
-                    explain.add_match(from_pat, subst, &self.memo, &mut self.unionfind);
-                let size_before_right = self.unionfind.size();
-                let right_added = explain.add_match(to_pat, subst, &self.memo, &mut self.unionfind);
-                let any_new_rhs = rhs_new || self.unionfind.size() > size_before_right;
-                self.to_union
-                    .push((left_added, right_added, Some(rule_name.into()), any_new_rhs));
-                true
-            }
-        } else {
-            self.union(id1, id2)
-        }
-    }
-
-    /// Marks two eclasses to be unioned given their ids.
-    ///
-    /// At the end of each iteration, these classes are unioned during
-    /// [`rebuild`](EGraph::rebuild).
+    /// Unions two eclasses given their ids.
     ///
     /// The given ids need not be canonical.
     /// The returned `bool` indicates whether a union is necessary,
@@ -591,16 +605,10 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// You must call [`rebuild`](EGraph::rebuild) to observe any effect.
     ///
     pub fn union(&mut self, id1: Id, id2: Id) -> bool {
-        self.clean = false;
         if self.explain.is_some() {
             panic!("Use union_instantiations when explanation mode is enabled.");
         }
-        if self.find_mut(id1) == self.find_mut(id2) {
-            false
-        } else {
-            self.to_union.push((id1, id2, None, false));
-            true
-        }
+        self.perform_union(id1, id2, None, false)
     }
 
     fn perform_union(
@@ -610,6 +618,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         rule: Option<Justification>,
         any_new_rhs: bool,
     ) -> bool {
+        self.clean = false;
         let mut id1 = self.find_mut(enode_id1);
         let mut id2 = self.find_mut(enode_id2);
         if id1 == id2 {
@@ -626,9 +635,8 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
         if let Some(explain) = &mut self.explain {
             explain.union(enode_id1, enode_id2, rule.unwrap(), any_new_rhs);
-        } else {
-            assert!(rule.is_none());
         }
+
         // make id1 the new root
         self.unionfind.union(id1, id2);
 
@@ -780,42 +788,23 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         true
     }
 
-    fn perform_to_union(&mut self) {
-        while !self.to_union.is_empty() {
-            let mut current = vec![];
-            std::mem::swap(&mut self.to_union, &mut current);
-            for (id1, id2, rule, any_new_rhs) in current.into_iter() {
-                self.perform_union(id1, id2, rule.map(Justification::Rule), any_new_rhs);
-            }
-        }
-    }
-
     #[inline(never)]
     fn process_unions(&mut self) -> usize {
         let mut n_unions = 0;
 
-        while !self.pending.is_empty()
-            || !self.to_union.is_empty()
-            || !self.analysis_pending.is_empty()
-        {
-            while !self.pending.is_empty() || !self.to_union.is_empty() {
-                self.perform_to_union();
-                assert!(self.to_union.is_empty());
-
-                while let Some((mut node, class)) = self.pending.pop() {
-                    node.update_children(|id| self.find_mut(id));
-                    if let Some(memo_class) = self.memo.insert(node, class) {
-                        let mut reason = None;
-                        if self.explain.is_some() {
-                            reason = Some(Justification::Congruence);
-                        }
-                        let did_something = self.perform_union(memo_class, class, reason, false);
-                        n_unions += did_something as usize;
-                    }
+        while !self.pending.is_empty() {
+            while let Some((mut node, class)) = self.pending.pop() {
+                node.update_children(|id| self.find_mut(id));
+                if let Some(memo_class) = self.memo.insert(node, class) {
+                    let did_something = self.perform_union(
+                        memo_class,
+                        class,
+                        Some(Justification::Congruence),
+                        false,
+                    );
+                    n_unions += did_something as usize;
                 }
             }
-            assert!(self.pending.is_empty());
-            assert!(self.to_union.is_empty());
 
             while let Some((node, class_id)) = self.analysis_pending.pop() {
                 let class_id = self.find_mut(class_id);
@@ -825,14 +814,13 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                 let did_merge = self.analysis.merge(&mut class.data, node_data);
                 if did_merge.0 {
                     self.analysis_pending.extend(class.parents.iter().cloned());
-                    N::modify(self, class_id);
+                    N::modify(self, class_id)
                 }
             }
         }
 
         assert!(self.pending.is_empty());
         assert!(self.analysis_pending.is_empty());
-        assert!(self.to_union.is_empty());
 
         n_unions
     }

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -398,6 +398,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                     } else {
                         new_node_q.push(false);
                     }
+
                     if let Some(explain) = &mut self.explain {
                         node.for_each(|child| {
                             if new_node_q[usize::from(child)] {
@@ -497,16 +498,18 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             let id = self.find(existing_id);
             // when explanations are enabled, we need a new representative for this expr
             if let Some(explain) = self.explain.as_mut() {
-                if !explain.uncanon_memo.contains_key(&original) {
+                if let Some(existing_explain) = explain.uncanon_memo.get(&original) {
+                    *existing_explain
+                } else {
                     let new_id = self.unionfind.make_set();
                     explain.add(original.clone(), new_id, new_id);
                     self.unionfind.union(id, new_id);
                     explain.union(existing_id, new_id, Justification::Congruence, true);
-                    return new_id;
+                    new_id
                 }
+            } else {
+                existing_id
             }
-
-            existing_id
         } else {
             let id = self.make_new_eclass(enode);
             if let Some(explain) = self.explain.as_mut() {

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -482,8 +482,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// If a copy is in the egraph, then [`add`] simply returns the id of the
     /// eclass in which the enode was found.
     ///
-    /// Like [`union`](EGraph::union), this modifies the e-graph,
-    /// so you must call [`rebuild`](EGraph::rebuild) any query operations.
+    /// Like [`union`](EGraph::union), this modifies the e-graph.
     ///
     /// [`add`]: EGraph::add()
     pub fn add(&mut self, enode: L) -> Id {
@@ -507,7 +506,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                 }
             }
 
-            id
+            existing_id
         } else {
             let id = self.make_new_eclass(enode);
             if let Some(explain) = self.explain.as_mut() {
@@ -607,14 +606,12 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// The given ids need not be canonical.
     /// The returned `bool` indicates whether a union is necessary,
     /// so it's `false` if they were already equivalent.
-    /// Both results are canonical.
     ///
     /// When explanations are enabled, this function is not available.
     /// Instead, use [`union_instantiations`](EGraph::union_instantiations).
     /// See [`explain_equivalence`](Runner::explain_equivalence) for a more detailed
     /// explanation of the feature.
     ///
-    /// You must call [`rebuild`](EGraph::rebuild) to observe any effect.
     ///
     pub fn union(&mut self, id1: Id, id2: Id) -> bool {
         if self.explain.is_some() {

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -850,14 +850,12 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// let ax = egraph.add_expr(&"(+ a x)".parse().unwrap());
     /// let ay = egraph.add_expr(&"(+ a y)".parse().unwrap());
 
-    /// // The effects of this union aren't yet visible;
-    /// // The union has not taken effect.
+    /// // Union x and y
     /// egraph.union(x, y);
-    /// // Classes: [x] [y] [ax] [ay] [a]
-    /// assert_eq!(egraph.number_of_classes(), 5);
-    /// assert_ne!(egraph.find(ax), egraph.find(ay));
+    /// // Classes: [x y] [ax] [ay] [a]
+    /// assert_eq!(egraph.find(x), egraph.find(y));
     ///
-    /// // Rebuilding applies the union and restores the invariants, finding
+    /// // Rebuilding restores the congruence invariant, finding
     /// // that ax and ay are equivalent.
     /// egraph.rebuild();
     /// // Classes: [x y] [ax ay] [a]

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -451,7 +451,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     {
         let enode = enode.borrow_mut();
         enode.update_children(|id| self.find(id));
-        self.memo.get(enode).map(|&id| id)
+        self.memo.get(enode).copied()
     }
 
     /// Lookup the eclass of the given [`RecExpr`].
@@ -502,7 +502,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                     *existing_explain
                 } else {
                     let new_id = self.unionfind.make_set();
-                    explain.add(original.clone(), new_id, new_id);
+                    explain.add(original, new_id, new_id);
                     self.unionfind.union(id, new_id);
                     explain.union(existing_id, new_id, Justification::Congruence, true);
                     new_id
@@ -513,7 +513,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         } else {
             let id = self.make_new_eclass(enode);
             if let Some(explain) = self.explain.as_mut() {
-                explain.add(original.clone(), id, id);
+                explain.add(original, id, id);
             }
 
             // now that we updated explanations, run the analysis for the new eclass

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -350,7 +350,6 @@ impl<L: Language> Explanation<L> {
         if let Some(lhs) = rewrite.searcher.get_pattern_ast() {
             if let Some(rhs) = rewrite.applier.get_pattern_ast() {
                 let rewritten = current.rewrite(lhs, rhs);
-                println!("Current {:?} \n Next {:?} \n Rewritten {:?} \n Rule {}", current, next, rewritten, rewrite.name);
                 if &rewritten != next {
                     return false;
                 }
@@ -864,7 +863,9 @@ impl<L: Language> Explain<L> {
         new_rhs: bool,
     ) {
         if let Justification::Congruence = justification {
-            assert!(self.explainfind[usize::from(node1)].node.matches(&self.explainfind[usize::from(node2)].node));
+            assert!(self.explainfind[usize::from(node1)]
+                .node
+                .matches(&self.explainfind[usize::from(node2)].node));
         }
         if new_rhs {
             self.set_existance_reason(node2, node1)

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -349,7 +349,9 @@ impl<L: Language> Explanation<L> {
     ) -> bool {
         if let Some(lhs) = rewrite.searcher.get_pattern_ast() {
             if let Some(rhs) = rewrite.applier.get_pattern_ast() {
-                if &current.rewrite(lhs, rhs) != next {
+                let rewritten = current.rewrite(lhs, rhs);
+                println!("Current {:?} \n Next {:?} \n Rewritten {:?} \n Rule {}", current, next, rewritten, rewrite.name);
+                if &rewritten != next {
                     return false;
                 }
             }
@@ -712,7 +714,15 @@ impl<L: Language> FlatTerm<L> {
     ) {
         match &pattern[location] {
             ENodeOrVar::Var(var) => {
-                bindings.insert(*var, self);
+                if let Some(existing) = bindings.get(var) {
+                    if existing != &self {
+                        panic!(
+                            "Invalid proof: binding for variable {:?} does not match between {:?} \n and \n {:?}",
+                            var, existing, self);
+                    }
+                } else {
+                    bindings.insert(*var, self);
+                }
             }
             ENodeOrVar::ENode(node) => {
                 // The node must match the rewrite or the proof is invalid.

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1047,7 +1047,6 @@ impl<L: Language> Explain<L> {
                 // add the children proofs to the last explanation
                 let current_node = &self.explainfind[usize::from(current)].node;
                 let next_node = &self.explainfind[usize::from(next)].node;
-                assert!(current_node.matches(next_node));
                 let mut subproofs = vec![];
 
                 for (left_child, right_child) in current_node

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,7 +1,7 @@
 use crate::Symbol;
 use crate::{
-    util::pretty_print, Analysis, ENodeOrVar, HashMap, HashSet, Id, Language, PatternAst, RecExpr,
-    Rewrite, Subst, UnionFind, Var,
+    util::pretty_print, Analysis, ENodeOrVar, HashMap, HashSet, Id, Language, PatternAst, Rewrite,
+    Var,
 };
 use std::fmt::{self, Debug, Display, Formatter};
 use std::rc::Rc;
@@ -36,7 +36,7 @@ struct ExplainNode<L: Language> {
 pub struct Explain<L: Language> {
     explainfind: Vec<ExplainNode<L>>,
     #[cfg_attr(feature = "serde-1", serde(with = "vectorize"))]
-    uncanon_memo: HashMap<L, Id>,
+    pub uncanon_memo: HashMap<L, Id>,
 }
 
 /// Explanation trees are the compact representation showing
@@ -819,6 +819,7 @@ impl<L: Language> Explain<L> {
     }
 
     pub(crate) fn add(&mut self, node: L, set: Id, existance_node: Id) -> Id {
+        assert_eq!(self.explainfind.len(), usize::from(set));
         self.uncanon_memo.insert(node.clone(), set);
         self.explainfind.push(ExplainNode {
             node,
@@ -829,87 +830,6 @@ impl<L: Language> Explain<L> {
             is_rewrite_forward: false,
         });
         set
-    }
-
-    fn add_expr(
-        &mut self,
-        expr: &RecExpr<L>,
-        memo: &HashMap<L, Id>,
-        unionfind: &mut UnionFind,
-    ) -> Id {
-        let nodes: Vec<ENodeOrVar<L>> = expr
-            .as_ref()
-            .iter()
-            .map(|node| ENodeOrVar::ENode(node.clone()))
-            .collect();
-        let pattern = PatternAst::from(nodes);
-        self.add_match(&pattern, &Default::default(), memo, unionfind)
-    }
-
-    // add_match uses the memo in order to re-discover matches
-    // given a substitution.
-    // This requires that congruence has been restored and the memo is up to date.
-    pub(crate) fn add_match(
-        &mut self,
-        pattern: &PatternAst<L>,
-        subst: &Subst,
-        memo: &HashMap<L, Id>,
-        unionfind: &mut UnionFind,
-    ) -> Id {
-        let nodes = pattern.as_ref().as_ref();
-        let mut new_ids = Vec::with_capacity(nodes.len());
-        let mut match_ids = Vec::with_capacity(nodes.len());
-        for node in nodes {
-            match node {
-                ENodeOrVar::Var(var) => {
-                    let bottom_id = unionfind.find(subst[*var]);
-                    new_ids.push(unionfind.find(bottom_id));
-                    match_ids.push(bottom_id);
-                }
-                ENodeOrVar::ENode(pattern_node) => {
-                    let node = pattern_node
-                        .clone()
-                        .map_children(|i| new_ids[usize::from(i)]);
-                    let new_congruent_node = pattern_node
-                        .clone()
-                        .map_children(|i| match_ids[usize::from(i)]);
-                    if let Some(existing_id) = self.uncanon_memo.get(&new_congruent_node) {
-                        new_ids.push(unionfind.find(*existing_id));
-                        match_ids.push(*existing_id);
-                    } else {
-                        let congruent_id = *memo.get(&node).unwrap_or_else(|| {
-                            panic!("Internal error! Pattern did not exist for substitution.");
-                        });
-
-                        let congruent_class = unionfind.find(congruent_id);
-
-                        new_ids.push(congruent_class);
-                        assert!(
-                            node == self.explainfind[usize::from(congruent_id)]
-                                .node
-                                .clone()
-                                .map_children(|id| unionfind.find(id))
-                        );
-
-                        let new_congruent_id =
-                            self.add(new_congruent_node, unionfind.make_set(), congruent_id);
-
-                        match_ids.push(new_congruent_id);
-                        // make the congruent_id we found the leader
-                        unionfind.union(congruent_class, new_congruent_id);
-                        self.union(
-                            new_congruent_id,
-                            congruent_id,
-                            Justification::Congruence,
-                            false,
-                        );
-                    }
-                }
-            }
-        }
-
-        let last_id = *match_ids.last().unwrap();
-        last_id
     }
 
     // reverse edges recursively to make this node the leader
@@ -942,65 +862,18 @@ impl<L: Language> Explain<L> {
         self.explainfind[usize::from(node1)].is_rewrite_forward = true;
     }
 
-    pub(crate) fn explain_matches(
-        &mut self,
-        left: &RecExpr<L>,
-        right: &PatternAst<L>,
-        subst: &Subst,
-        memo: &HashMap<L, Id>,
-        unionfind: &mut UnionFind,
-    ) -> Explanation<L> {
-        let left_added = self.add_expr(left, memo, unionfind);
-        let right_added = self.add_match(right, &subst, memo, unionfind);
+    pub(crate) fn explain_equivalence(&mut self, left: Id, right: Id) -> Explanation<L> {
         let mut cache = Default::default();
         let mut enode_cache = Default::default();
-        Explanation::new(self.explain_enodes(left_added, right_added, &mut cache, &mut enode_cache))
+        Explanation::new(self.explain_enodes(left, right, &mut cache, &mut enode_cache))
     }
 
-    pub(crate) fn explain_equivalence(
-        &mut self,
-        left: &RecExpr<L>,
-        right: &RecExpr<L>,
-        memo: &HashMap<L, Id>,
-        unionfind: &mut UnionFind,
-    ) -> Explanation<L> {
-        let left_added = self.add_expr(left, memo, unionfind);
-        let right_added = self.add_expr(right, memo, unionfind);
-        let mut cache = Default::default();
-        let mut enode_cache = Default::default();
-        Explanation::new(self.explain_enodes(left_added, right_added, &mut cache, &mut enode_cache))
-    }
-
-    pub(crate) fn explain_existance(
-        &mut self,
-        left: &RecExpr<L>,
-        memo: &HashMap<L, Id>,
-        unionfind: &mut UnionFind,
-    ) -> Explanation<L> {
-        let left_added = self.add_expr(left, memo, unionfind);
+    pub(crate) fn explain_existance(&mut self, left: Id) -> Explanation<L> {
         let mut cache = Default::default();
         let mut enode_cache = Default::default();
         Explanation::new(self.explain_enode_existance(
-            left_added,
-            self.node_to_explanation(left_added, &mut enode_cache),
-            &mut cache,
-            &mut enode_cache,
-        ))
-    }
-
-    pub(crate) fn explain_existance_pattern(
-        &mut self,
-        left: &PatternAst<L>,
-        subst: &Subst,
-        memo: &HashMap<L, Id>,
-        unionfind: &mut UnionFind,
-    ) -> Explanation<L> {
-        let left_added = self.add_match(left, &subst, memo, unionfind);
-        let mut cache = Default::default();
-        let mut enode_cache = Default::default();
-        Explanation::new(self.explain_enode_existance(
-            left_added,
-            self.node_to_explanation(left_added, &mut enode_cache),
+            left,
+            self.node_to_explanation(left, &mut enode_cache),
             &mut cache,
             &mut enode_cache,
         ))

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -852,6 +852,9 @@ impl<L: Language> Explain<L> {
         justification: Justification,
         new_rhs: bool,
     ) {
+        if let Justification::Congruence = justification {
+            assert!(self.explainfind[usize::from(node1)].node.matches(&self.explainfind[usize::from(node2)].node));
+        }
         if new_rhs {
             self.set_existance_reason(node2, node1)
         }
@@ -1047,6 +1050,7 @@ impl<L: Language> Explain<L> {
                 // add the children proofs to the last explanation
                 let current_node = &self.explainfind[usize::from(current)].node;
                 let next_node = &self.explainfind[usize::from(next)].node;
+                assert!(current_node.matches(next_node));
                 let mut subproofs = vec![];
 
                 for (left_child, right_child) in current_node

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -715,6 +715,7 @@ impl<L: Language> FlatTerm<L> {
                 bindings.insert(*var, self);
             }
             ENodeOrVar::ENode(node) => {
+                // The node must match the rewrite or the proof is invalid.
                 assert!(node.matches(&self.node));
                 let mut counter = 0;
                 node.for_each(|child| {


### PR DESCRIPTION
[#115] Introduces explanations- proofs of equality between two terms in the egraph. To support the PR, egg was modified so that all unions were delayed until rebuild is called. This made explanations easier to implement because there is an up-to-date hashcons (memo for enodes in the egraph).

However, it turns out that carefully re-writing how enodes are added to the egraph avoids this issue. This PR restores egg's functionality to perform unions immediately. It also restores the rebuild algorithm to what it was before proofs were added. The core idea of the PR is to make sure that proofs have access to the correct uncanonicalized enode.