### PR TITLE
MultiPatterns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod explain;
 mod extract;
 mod language;
 mod machine;
+mod multipattern;
 mod pattern;
 mod rewrite;
 mod run;
@@ -84,6 +85,7 @@ pub use {
     explain::{Explanation, FlatExplanation, FlatTerm, TreeExplanation, TreeTerm},
     extract::*,
     language::*,
+    multipattern::*,
     pattern::{ENodeOrVar, Pattern, PatternAst, SearchMatches},
     rewrite::{Applier, Condition, ConditionEqual, ConditionalApplier, Rewrite, Searcher},
     run::*,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -21,6 +21,7 @@ enum Instruction<L> {
     Bind { node: L, i: Reg, out: Reg },
     Compare { i: Reg, j: Reg },
     Lookup { term: Vec<ENodeOrReg<L>>, i: Reg },
+    Scan { out: Reg },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,6 +99,16 @@ impl Machine {
                         self.run(egraph, remaining_instructions, subst, yield_fn)
                     });
                 }
+                Instruction::Scan { out } => {
+                    let remaining_instructions = instructions.as_slice();
+                    let nclasses = egraph.number_of_classes() as u32;
+                    for id in 0..nclasses {
+                        self.reg.truncate(out.0 as usize);
+                        self.reg.push(Id(id));
+                        self.run(egraph, remaining_instructions, subst, yield_fn)
+                    }
+                    return;
+                }
                 Instruction::Compare { i, j } => {
                     if egraph.find(self.reg(*i)) != egraph.find(self.reg(*j)) {
                         return;
@@ -132,52 +143,29 @@ impl Machine {
     }
 }
 
-struct Compiler<'a, L> {
-    pattern: &'a PatternAst<L>,
+struct Compiler<L> {
     v2r: IndexMap<Var, Reg>,
     free_vars: Vec<HashSet<Var>>,
     subtree_size: Vec<usize>,
     todo_nodes: HashMap<(Id, Reg), L>,
     instructions: Vec<Instruction<L>>,
+    next_reg: Reg,
 }
 
-impl<'a, L: Language> Compiler<'a, L> {
-    fn new(pattern: &'a PatternAst<L>) -> Self {
-        let len = pattern.as_ref().len();
-        let mut free_vars: Vec<HashSet<Var>> = Vec::with_capacity(len);
-        let mut subtree_size = Vec::with_capacity(len);
-
-        for node in pattern.as_ref() {
-            let mut free = HashSet::default();
-            let mut size = 0;
-            match node {
-                ENodeOrVar::ENode(n) => {
-                    size = 1;
-                    for &child in n.children() {
-                        free.extend(&free_vars[usize::from(child)]);
-                        size += subtree_size[usize::from(child)];
-                    }
-                }
-                ENodeOrVar::Var(v) => {
-                    free.insert(*v);
-                }
-            }
-            free_vars.push(free);
-            subtree_size.push(size);
-        }
-
+impl<L: Language> Compiler<L> {
+    fn new() -> Self {
         Self {
-            pattern,
-            free_vars,
-            subtree_size,
+            free_vars: Default::default(),
+            subtree_size: Default::default(),
             v2r: Default::default(),
             todo_nodes: Default::default(),
             instructions: Default::default(),
+            next_reg: Reg(0),
         }
     }
 
-    fn add_todo(&mut self, id: Id, reg: Reg) {
-        match &self.pattern[id] {
+    fn add_todo(&mut self, pattern: &PatternAst<L>, id: Id, reg: Reg) {
+        match &pattern[id] {
             ENodeOrVar::Var(v) => {
                 if let Some(&j) = self.v2r.get(v) {
                     self.instructions.push(Instruction::Compare { i: reg, j })
@@ -188,6 +176,31 @@ impl<'a, L: Language> Compiler<'a, L> {
             ENodeOrVar::ENode(pat) => {
                 self.todo_nodes.insert((id, reg), pat.clone());
             }
+        }
+    }
+
+    fn queue_pattern(&mut self, pattern: &PatternAst<L>) {
+        let len = pattern.as_ref().len();
+        self.free_vars = Vec::with_capacity(len);
+        self.subtree_size = Vec::with_capacity(len);
+
+        for node in pattern.as_ref() {
+            let mut free = HashSet::default();
+            let mut size = 0;
+            match node {
+                ENodeOrVar::ENode(n) => {
+                    size = 1;
+                    for &child in n.children() {
+                        free.extend(&self.free_vars[usize::from(child)]);
+                        size += self.subtree_size[usize::from(child)];
+                    }
+                }
+                ENodeOrVar::Var(v) => {
+                    free.insert(*v);
+                }
+            }
+            self.free_vars.push(free);
+            self.subtree_size.push(size);
         }
     }
 
@@ -222,15 +235,23 @@ impl<'a, L: Language> Compiler<'a, L> {
             .all(|v| self.v2r.contains_key(v))
     }
 
-    fn compile(mut self) -> Program<L> {
-        let last_i = self.pattern.as_ref().len() - 1;
-        let mut next_out = Reg(1);
+    fn compile(&mut self, pattern: &PatternAst<L>) {
+        self.queue_pattern(pattern);
+        let last_i = pattern.as_ref().len() - 1;
 
-        self.add_todo(Id::from(last_i), Reg(0));
+        // check if already bound in v2r
+        let mut next_out = Reg(self.next_reg.0 + 1);
+
+        if !self.instructions.is_empty() {
+            // After first pattern needs scan
+            self.instructions
+                .push(Instruction::Scan { out: self.next_reg });
+        }
+        self.add_todo(pattern, Id::from(last_i), self.next_reg);
 
         while let Some(((id, reg), node)) = self.next() {
             if self.is_ground_now(id) && !node.is_leaf() {
-                let extracted = self.pattern.extract(id);
+                let extracted = pattern.extract(id);
                 self.instructions.push(Instruction::Lookup {
                     i: reg,
                     term: extracted
@@ -255,11 +276,14 @@ impl<'a, L: Language> Compiler<'a, L> {
                 });
 
                 for (i, &child) in node.children().iter().enumerate() {
-                    self.add_todo(child, Reg(out.0 + i as u32));
+                    self.add_todo(pattern, child, Reg(out.0 + i as u32));
                 }
             }
         }
+        self.next_reg = next_out;
+    }
 
+    fn extract(self) -> Program<L> {
         let mut subst = Subst::default();
         for (v, r) in self.v2r {
             subst.insert(v, Id::from(r.0 as usize));
@@ -273,8 +297,20 @@ impl<'a, L: Language> Compiler<'a, L> {
 
 impl<L: Language> Program<L> {
     pub(crate) fn compile_from_pat(pattern: &PatternAst<L>) -> Self {
-        let program = Compiler::new(pattern).compile();
+        let mut compiler = Compiler::new();
+        compiler.compile(pattern);
+        let program = compiler.extract();
         log::debug!("Compiled {:?} to {:?}", pattern.as_ref(), program);
+        program
+    }
+
+    pub(crate) fn compile_from_multi_pat(patterns: &[PatternAst<L>]) -> Self {
+        let mut compiler = Compiler::new();
+        for pattern in patterns {
+            compiler.compile(pattern);
+        }
+        let program = compiler.extract();
+        //log::debug!("Compiled {:?} to {:?}", pattern.as_ref(), program);
         program
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -223,6 +223,10 @@ For each of these, the macro will wrap the given applier in a
 [`ConditionalApplier`] with the given condition, with the first condition being
 the outermost, and the last condition being the innermost.
 
+The macro can also be used to create multipatterns
+using the form `rewrite!(name; multipattern |- multipattern)`.
+Currently you cannot combine patterns and multipatterns.
+
 # Example
 ```
 # use egg::*;
@@ -305,7 +309,7 @@ macro_rules! rewrite {
     // limited multipattern support
     (
         $name:expr;
-        $lhs:literal ==> $rhs:literal
+        $lhs:tt |- $rhs:tt
     )  => {{
         let searcher = $crate::__rewrite!(@parse MultiPattern $lhs);
         let applier = $crate::__rewrite!(@parse MultiPattern $rhs);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -223,10 +223,6 @@ For each of these, the macro will wrap the given applier in a
 [`ConditionalApplier`] with the given condition, with the first condition being
 the outermost, and the last condition being the innermost.
 
-The macro can also be used to create multipatterns
-using the form `rewrite!(name; multipattern |- multipattern)`.
-Currently you cannot combine patterns and multipatterns.
-
 # Example
 ```
 # use egg::*;
@@ -306,10 +302,21 @@ macro_rules! rewrite {
             $crate::rewrite!(name2; $rhs => $lhs $(if $cond)*)
         ]
     }};
+}
+
+/** A macro to easily make [`Rewrite`]s using [`MultiPattern`]s.
+
+Similar to the [`rewrite!`] macro,
+this macro uses the form `multi_rewrite!(name; multipattern => multipattern)`.
+String literals will be parsed a [`MultiPattern`]s.
+
+**/
+#[macro_export]
+macro_rules! multi_rewrite {
     // limited multipattern support
     (
         $name:expr;
-        $lhs:tt |- $rhs:tt
+        $lhs:tt => $rhs:tt
     )  => {{
         let searcher = $crate::__rewrite!(@parse MultiPattern $lhs);
         let applier = $crate::__rewrite!(@parse MultiPattern $rhs);

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -222,15 +222,15 @@ mod tests {
         assert_eq!(n_matches("?x = (f a a), ?x = (f a c)"), 0);
         assert_eq!(n_matches("?x = (f a b), ?x = (f a c)"), 1);
     }
-    
+
     #[test]
     fn unbound_rhs() {
         let mut egraph = EGraph::default();
         let _x = egraph.add_expr(&"(x)".parse().unwrap());
         let rules = vec![
-            // Rule creates y and z if they don't exist. Crashes with current parsing
+            // Rule creates y and z if they don't exist.
             rewrite!("rule1"; "?x = (x)" |- "?y = (y), ?y = (z)"),
-            // Can't fire. `y` and `z` don't already exist in egraph
+            // Can't fire without above rule. `y` and `z` don't already exist in egraph
             rewrite!("rule2"; "?x = (x), ?y = (y), ?z = (z)" |- "?y = (y), ?y = (z)"),
         ];
         let mut runner = Runner::default().with_egraph(egraph).run(&rules);

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -171,14 +171,18 @@ impl<L: Language, A: Analysis<L>> Applier<L, A> for MultiPattern<L> {
     }
 
     fn vars(&self) -> Vec<Var> {
+        let mut bound_vars = HashSet::default();
         let mut vars = vec![];
-        // TODO are unbound binding vars allowed?
-        for (_v, pat) in &self.asts {
+        for (bv, pat) in &self.asts {
             for n in pat.as_ref() {
                 if let ENodeOrVar::Var(v) = n {
-                    vars.push(*v)
+                    // using vars that are already bound doesn't count
+                    if !bound_vars.contains(v) {
+                        vars.push(*v)
+                    }
                 }
             }
+            bound_vars.insert(bv);
         }
         vars.sort();
         vars.dedup();
@@ -193,9 +197,20 @@ mod tests {
     type EGraph = crate::EGraph<S, ()>;
 
     impl EGraph {
-        fn add_string(self: &mut Self, s: &str) -> Id {
+        fn add_string(&mut self, s: &str) -> Id {
             self.add_expr(&s.parse().unwrap())
         }
+    }
+
+    #[test]
+    #[should_panic = "unbound var ?z"]
+    fn bad_unbound_var() {
+        let _: Rewrite<S, ()> = rewrite!("foo"; "?x = (foo ?y)" |- "?x = ?z");
+    }
+
+    #[test]
+    fn ok_unbound_var() {
+        let _: Rewrite<S, ()> = rewrite!("foo"; "?x = (foo ?y)" |- "?z = (baz ?y), ?x = ?z");
     }
 
     #[test]
@@ -254,9 +269,13 @@ mod tests {
         let z1 = egraph.add_string("(tag z ctx2)");
         egraph.union(x1, y1);
         egraph.union(y2, z2);
-        let rules = vec![
-            rewrite!("context-transfer"; "?x = (tag ?a ?ctx1) = (tag ?b ?ctx1), ?t = (lte ?ctx1 ?ctx2), ?a1 = (tag ?a ?ctx2), ?b1 = (tag ?b ?ctx2)" |- "?a1 = ?b1"),
-        ];
+        let rules = vec![rewrite!("context-transfer"; 
+                     "?x = (tag ?a ?ctx1) = (tag ?b ?ctx1), 
+                      ?t = (lte ?ctx1 ?ctx2), 
+                      ?a1 = (tag ?a ?ctx2), 
+                      ?b1 = (tag ?b ?ctx2)" 
+                      |- 
+                      "?a1 = ?b1")];
         let runner = Runner::default().with_egraph(egraph).run(&rules);
         assert_eq!(runner.egraph.find(x1), runner.egraph.find(y1));
         assert_eq!(runner.egraph.find(y2), runner.egraph.find(z2));
@@ -264,7 +283,7 @@ mod tests {
         assert_eq!(runner.egraph.find(x2), runner.egraph.find(y2));
         assert_eq!(runner.egraph.find(x2), runner.egraph.find(z2));
 
-        assert!(runner.egraph.find(y1) != runner.egraph.find(z1));
-        assert!(runner.egraph.find(x1) != runner.egraph.find(z1));
+        assert_ne!(runner.egraph.find(y1), runner.egraph.find(z1));
+        assert_ne!(runner.egraph.find(x1), runner.egraph.find(z1));
     }
 }

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -1,0 +1,169 @@
+use std::str::FromStr;
+use thiserror::Error;
+
+use crate::*;
+
+pub struct MultiPattern<L> {
+    asts: Vec<(Var, PatternAst<L>)>,
+    program: machine::Program<L>,
+}
+
+impl<L: Language> MultiPattern<L> {
+    pub fn new(asts: Vec<(Var, PatternAst<L>)>) -> Self {
+        let program = machine::Program::compile_from_multi_pat(&asts);
+        Self { asts, program }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MultiPatternParseError<E> {
+    #[error(transparent)]
+    PatternParseError(E),
+    PatternAssignmentError(String),
+    VariableError(<Var as FromStr>::Err),
+}
+
+impl<L: Language + FromOp> FromStr for MultiPattern<L> {
+    type Err = MultiPatternParseError<<PatternAst<L> as FromStr>::Err>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use MultiPatternParseError::*;
+        let mut asts = vec![];
+        for split in s.trim().split(',') {
+            let split = split.trim();
+            if split.is_empty() {
+                continue;
+            }
+            let mut parts = split.split('=');
+            let vs: &str = parts
+                .next()
+                .ok_or_else(|| PatternAssignmentError(split.into()))?;
+            let v: Var = vs.trim().parse().map_err(VariableError)?;
+            let ps = parts
+                .map(|p| p.trim().parse())
+                .collect::<Result<Vec<PatternAst<L>>, _>>()
+                .map_err(PatternParseError)?;
+            if ps.is_empty() {
+                return Err(PatternAssignmentError(split.into()));
+            }
+            asts.extend(ps.into_iter().map(|p| (v, p)))
+        }
+        Ok(MultiPattern::new(asts))
+    }
+}
+
+impl<L: Language, A: Analysis<L>> Searcher<L, A> for MultiPattern<L> {
+    fn search_eclass(&self, egraph: &EGraph<L, A>, eclass: Id) -> Option<SearchMatches<L>> {
+        let substs = self.program.run(egraph, eclass);
+        if substs.is_empty() {
+            None
+        } else {
+            Some(SearchMatches {
+                eclass,
+                substs,
+                ast: None,
+            })
+        }
+    }
+
+    fn vars(&self) -> Vec<Var> {
+        let mut vars = vec![];
+        for (v, pat) in &self.asts {
+            vars.push(*v);
+            for n in pat.as_ref() {
+                if let ENodeOrVar::Var(v) = n {
+                    vars.push(*v)
+                }
+            }
+        }
+        vars.sort();
+        vars.dedup();
+        vars
+    }
+}
+
+impl<L: Language, A: Analysis<L>> Applier<L, A> for MultiPattern<L> {
+    fn apply_one(
+        &self,
+        _egraph: &mut EGraph<L, A>,
+        _eclass: Id,
+        _subst: &Subst,
+        _searcher_ast: Option<&PatternAst<L>>,
+        _rule_name: Symbol,
+    ) -> Vec<Id> {
+        panic!("Multipatterns do not support apply_one")
+    }
+
+    fn apply_matches(
+        &self,
+        egraph: &mut EGraph<L, A>,
+        matches: &[SearchMatches<L>],
+        _rule_name: Symbol,
+    ) -> Vec<Id> {
+        // TODO explanations?
+        // the ids returned are kinda garbage
+        let mut added = vec![];
+        for mat in matches {
+            for subst in &mat.substs {
+                let mut id_buf = vec![];
+                for (i, (v, p)) in self.asts.iter().enumerate() {
+                    id_buf.resize(p.as_ref().len(), 0.into());
+                    let id1 = crate::pattern::apply_pat(&mut id_buf, p.as_ref(), egraph, subst);
+                    let id2 = subst[*v];
+                    egraph.union(id1, id2);
+                    if i == 0 {
+                        added.push(id1)
+                    }
+                }
+            }
+        }
+        added
+    }
+
+    fn vars(&self) -> Vec<Var> {
+        let mut vars = vec![];
+        // TODO are unbound binding vars allowed?
+        for (_v, pat) in &self.asts {
+            for n in pat.as_ref() {
+                if let ENodeOrVar::Var(v) = n {
+                    vars.push(*v)
+                }
+            }
+        }
+        vars.sort();
+        vars.dedup();
+        vars
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{SymbolLang as S, *};
+
+    type EGraph = crate::EGraph<S, ()>;
+
+    #[test]
+    fn multi_patterns() {
+        crate::init_logger();
+        let mut egraph = EGraph::default();
+        let _ = egraph.add_expr(&"(f a a)".parse().unwrap());
+        let ab = egraph.add_expr(&"(f a b)".parse().unwrap());
+        let ac = egraph.add_expr(&"(f a c)".parse().unwrap());
+        egraph.union(ab, ac);
+        egraph.rebuild();
+
+        let n_matches = |multipattern: &str| -> usize {
+            let mp: MultiPattern<S> = multipattern.parse().unwrap();
+            mp.n_matches(&egraph)
+        };
+
+        assert_eq!(n_matches("?x = (f a a),   ?y = (f ?c b)"), 1);
+        assert_eq!(n_matches("?x = (f a a),   ?y = (f a b)"), 1);
+        assert_eq!(n_matches("?x = (f a a),   ?y = (f a a)"), 1);
+        assert_eq!(n_matches("?x = (f ?a ?b), ?y = (f ?c ?d)"), 9);
+        assert_eq!(n_matches("?x = (f ?a a),  ?y = (f ?a b)"), 1);
+
+        assert_eq!(n_matches("?x = (f a a), ?x = (f a c)"), 0);
+        assert_eq!(n_matches("?x = (f a b), ?x = (f a c)"), 1);
+    }
+}

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -12,7 +12,7 @@ use crate::*;
 /// Multipatterns are good for writing graph rewrites or datalog-style rules.
 ///
 /// You can create multipatterns via the [`MultiPattern::new`] function or the
-/// [`rewrite!`] macro.
+/// [`multi_rewrite!`] macro.
 ///
 /// [`MultiPattern`] implements both [`Searcher`] and [`Applier`].
 /// When searching a multipattern, the result ensures that
@@ -205,12 +205,12 @@ mod tests {
     #[test]
     #[should_panic = "unbound var ?z"]
     fn bad_unbound_var() {
-        let _: Rewrite<S, ()> = rewrite!("foo"; "?x = (foo ?y)" |- "?x = ?z");
+        let _: Rewrite<S, ()> = multi_rewrite!("foo"; "?x = (foo ?y)" => "?x = ?z");
     }
 
     #[test]
     fn ok_unbound_var() {
-        let _: Rewrite<S, ()> = rewrite!("foo"; "?x = (foo ?y)" |- "?z = (baz ?y), ?x = ?z");
+        let _: Rewrite<S, ()> = multi_rewrite!("foo"; "?x = (foo ?y)" => "?z = (baz ?y), ?x = ?z");
     }
 
     #[test]
@@ -244,9 +244,9 @@ mod tests {
         let _x = egraph.add_expr(&"(x)".parse().unwrap());
         let rules = vec![
             // Rule creates y and z if they don't exist.
-            rewrite!("rule1"; "?x = (x)" |- "?y = (y), ?y = (z)"),
+            multi_rewrite!("rule1"; "?x = (x)" => "?y = (y), ?y = (z)"),
             // Can't fire without above rule. `y` and `z` don't already exist in egraph
-            rewrite!("rule2"; "?x = (x), ?y = (y), ?z = (z)" |- "?y = (y), ?y = (z)"),
+            multi_rewrite!("rule2"; "?x = (x), ?y = (y), ?z = (z)" => "?y = (y), ?y = (z)"),
         ];
         let mut runner = Runner::default().with_egraph(egraph).run(&rules);
         let y = runner.egraph.add_expr(&"(y)".parse().unwrap());
@@ -269,12 +269,12 @@ mod tests {
         let z1 = egraph.add_string("(tag z ctx2)");
         egraph.union(x1, y1);
         egraph.union(y2, z2);
-        let rules = vec![rewrite!("context-transfer"; 
+        let rules = vec![multi_rewrite!("context-transfer"; 
                      "?x = (tag ?a ?ctx1) = (tag ?b ?ctx1), 
                       ?t = (lte ?ctx1 ?ctx2), 
                       ?a1 = (tag ?a ?ctx2), 
                       ?b1 = (tag ?b ?ctx2)" 
-                      |- 
+                      =>
                       "?a1 = ?b1")];
         let runner = Runner::default().with_egraph(egraph).run(&rules);
         assert_eq!(runner.egraph.find(x1), runner.egraph.find(y1));

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -3,12 +3,54 @@ use thiserror::Error;
 
 use crate::*;
 
+/// A set of open expressions bound to variables.
+///
+/// Multipatterns bind many expressions to variables,
+/// allowing for simulataneous searching or application of many terms
+/// constrained to the same substitution.
+///
+/// Multipatterns are good for writing graph rewrites or datalog-style rules.
+///
+/// You can create multipatterns via the [`MultiPattern::new`] function or the
+/// [`rewrite!`] macro.
+///
+/// [`MultiPattern`] implements both [`Searcher`] and [`Applier`].
+/// When searching a multipattern, the result ensures that
+/// patterns bound to the same variable are equivalent.
+/// When applying a mulitpattern, patterns bound a variable occuring in the
+/// searcher are unioned with that e-class.
+///
+/// Multipatterns currently do not support the explanations feature.
+#[derive(Debug, PartialEq, Clone)]
 pub struct MultiPattern<L> {
     asts: Vec<(Var, PatternAst<L>)>,
     program: machine::Program<L>,
 }
 
 impl<L: Language> MultiPattern<L> {
+    /// Creates a new multipattern, binding the given patterns to the corresponding variables.
+    ///
+    /// ```
+    /// use egg::*;
+    ///
+    /// let mut egraph = EGraph::<SymbolLang, ()>::default();
+    /// egraph.add_expr(&"(f a a)".parse().unwrap());
+    /// egraph.add_expr(&"(f a b)".parse().unwrap());
+    /// egraph.add_expr(&"(g a a)".parse().unwrap());
+    /// egraph.add_expr(&"(g a b)".parse().unwrap());
+    /// egraph.rebuild();
+    ///
+    /// let f_pat: PatternAst<SymbolLang> = "(f ?x ?y)".parse().unwrap();
+    /// let g_pat: PatternAst<SymbolLang> = "(g ?x ?y)".parse().unwrap();
+    /// let v1: Var = "?v1".parse().unwrap();
+    /// let v2: Var = "?v2".parse().unwrap();
+    ///
+    /// let multipattern = MultiPattern::new(vec![(v1, f_pat), (v2, g_pat)]);
+    /// // you can also parse multipatterns
+    /// assert_eq!(multipattern, "?v1 = (f ?x ?y), ?v2 = (g ?x ?y)".parse().unwrap());
+    ///
+    /// assert_eq!(multipattern.n_matches(&egraph), 2);
+    /// ```
     pub fn new(asts: Vec<(Var, PatternAst<L>)>) -> Self {
         let program = machine::Program::compile_from_multi_pat(&asts);
         Self { asts, program }
@@ -16,10 +58,16 @@ impl<L: Language> MultiPattern<L> {
 }
 
 #[derive(Debug, Error)]
+/// An error raised when parsing a [`MultiPattern`]
 pub enum MultiPatternParseError<E> {
+    /// One of the patterns in the multipattern failed to parse.
     #[error(transparent)]
     PatternParseError(E),
+    /// One of the clauses in the multipattern wasn't of the form `?var (= pattern)+`.
+    #[error("Bad clause in the multipattern: {0}")]
     PatternAssignmentError(String),
+    /// One of the variables failed to parse.
+    #[error(transparent)]
     VariableError(<Var as FromStr>::Err),
 }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -467,34 +467,4 @@ mod tests {
         assert_eq!(n_matches("(f ?x (g ?x))))"), 1);
         assert_eq!(n_matches("(h ?x 0 0)"), 1);
     }
-
-    #[test]
-    fn multi_patterns() {
-        crate::init_logger();
-        let mut egraph = EGraph::default();
-        egraph.add_expr(&"(f a a)".parse().unwrap());
-        egraph.add_expr(&"(f a b)".parse().unwrap());
-        egraph.rebuild();
-
-        let n_matches = |pats: &[&str]| -> usize {
-            let pats: Vec<_> = pats
-                .iter()
-                .map(|s: &&str| (None, s.parse::<PatternAst<S>>().unwrap()))
-                .collect();
-            let program = machine::Program::compile_from_multi_pat(&pats);
-            egraph
-                .classes()
-                .map(|e| {
-                    let subst = program.run(&egraph, e.id);
-                    subst.len()
-                })
-                .sum()
-        };
-
-        assert_eq!(n_matches(&["(f a a)", "(f ?c b)"]), 1);
-        assert_eq!(n_matches(&["(f a a)", "(f a b)"]), 1);
-        assert_eq!(n_matches(&["(f a a)", "(f a a)"]), 1);
-        assert_eq!(n_matches(&["(f ?a ?b)", "(f ?c ?d)"]), 4);
-        assert_eq!(n_matches(&["(f ?a a)", "(f ?a b)"]), 1);
-    }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -467,4 +467,33 @@ mod tests {
         assert_eq!(n_matches("(f ?x (g ?x))))"), 1);
         assert_eq!(n_matches("(h ?x 0 0)"), 1);
     }
+
+    #[test]
+    fn multi_patterns() {
+        crate::init_logger();
+        let mut egraph = EGraph::default();
+        egraph.add_expr(&"(f a a)".parse().unwrap());
+        egraph.add_expr(&"(f c b)".parse().unwrap());
+        egraph.rebuild();
+
+        let n_matches = |pats: &[&str]| -> usize {
+            let pats: Vec<_> = pats
+                .iter()
+                .map(|s: &&str| s.parse::<PatternAst<S>>().unwrap())
+                .collect();
+            let program = machine::Program::compile_from_multi_pat(&pats);
+            egraph
+                .classes()
+                .map(|e| {
+                    let subst = program.run(&egraph, e.id);
+                    subst.len()
+                })
+                .sum()
+        };
+
+        assert_eq!(n_matches(&["(f a a)", "(f ?c b)"]), 1);
+        assert_eq!(n_matches(&["(f a a)", "(f b b)"]), 0);
+        assert_eq!(n_matches(&["(f a a)", "(f a a)"]), 1);
+        assert_eq!(n_matches(&["(f ?a ?b)", "(f ?c ?d)"]), 4);
+    }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -473,13 +473,13 @@ mod tests {
         crate::init_logger();
         let mut egraph = EGraph::default();
         egraph.add_expr(&"(f a a)".parse().unwrap());
-        egraph.add_expr(&"(f c b)".parse().unwrap());
+        egraph.add_expr(&"(f a b)".parse().unwrap());
         egraph.rebuild();
 
         let n_matches = |pats: &[&str]| -> usize {
             let pats: Vec<_> = pats
                 .iter()
-                .map(|s: &&str| s.parse::<PatternAst<S>>().unwrap())
+                .map(|s: &&str| (None, s.parse::<PatternAst<S>>().unwrap()))
                 .collect();
             let program = machine::Program::compile_from_multi_pat(&pats);
             egraph
@@ -492,8 +492,9 @@ mod tests {
         };
 
         assert_eq!(n_matches(&["(f a a)", "(f ?c b)"]), 1);
-        assert_eq!(n_matches(&["(f a a)", "(f b b)"]), 0);
+        assert_eq!(n_matches(&["(f a a)", "(f a b)"]), 1);
         assert_eq!(n_matches(&["(f a a)", "(f a a)"]), 1);
         assert_eq!(n_matches(&["(f ?a ?b)", "(f ?c ?d)"]), 4);
+        assert_eq!(n_matches(&["(f ?a a)", "(f ?a b)"]), 1);
     }
 }

--- a/tests/datalog.rs
+++ b/tests/datalog.rs
@@ -101,3 +101,19 @@ fn ctx_transfer() {
     assert!(runner.egraph.find(y1) != runner.egraph.find(z1));
     assert!(runner.egraph.find(x1) != runner.egraph.find(z1));
 }
+
+#[test]
+fn unbound_rhs() {
+    let mut egraph = EGraph::<Lang, ()>::default();
+    let x = egraph.add_expr(&"(x)".parse().unwrap());
+    let rules = vec![
+        // Rule creates y and z if they don't exist. Crashes with current parsing
+        rewrite!("test"; "?x = (x)" |- "?y = (y), ?y = (z)"),
+        // Can't fire. `y` and `z` don't already exist in egraph
+        rewrite!("test"; "?x = (x), ?y = (y), ?z = (z)" |- "?y = (y), ?y = (z)"),
+    ];
+    let mut runner = Runner::default().with_egraph(egraph).run(&rules);
+    let y = runner.egraph.add_expr(&"(y)".parse().unwrap());
+    let z = runner.egraph.add_expr(&"(z)".parse().unwrap());
+    assert_eq!(runner.egraph.find(y), runner.egraph.find(z));
+}

--- a/tests/datalog.rs
+++ b/tests/datalog.rs
@@ -11,6 +11,7 @@ define_language! {
 trait DatalogExtTrait {
     fn assert(&mut self, s: &str);
     fn check(&mut self, s: &str);
+    fn check_not(&mut self, s: &str);
 }
 
 impl DatalogExtTrait for EGraph<Lang, ()> {
@@ -31,6 +32,15 @@ impl DatalogExtTrait for EGraph<Lang, ()> {
             assert_eq!(true_id, id, "{} is not true", e);
         }
     }
+
+    fn check_not(&mut self, s: &str) {
+        let true_id = self.add(Lang::True);
+        for e in s.split(',') {
+            let exp = e.trim().parse().unwrap();
+            let id = self.add_expr(&exp);
+            assert!(true_id != id, "{} is not true", e);
+        }
+    }
 }
 
 #[test]
@@ -44,4 +54,50 @@ fn path() {
 
     let mut runner = Runner::default().with_egraph(egraph).run(&rules);
     runner.egraph.check("(path 1 4)");
+    runner.egraph.check_not("(path 4 1)");
+}
+
+#[test]
+fn path2() {
+    // `pred` function symbol allows us to insert without truth.
+    let mut egraph = EGraph::<Lang, ()>::default();
+    egraph.assert("(edge 1 2), (edge 2 3), (edge 3 4), (edge 1 4)");
+    let rules = vec![
+        rewrite!("base-case"; "?x = (edge ?a ?b), ?t = true" |- "?t = (pred (path ?a ?b))"),
+        rewrite!("transitive"; "?x = (path ?a ?b), ?y = (edge ?b ?c), ?t = true" |- "?t = (pred (path ?a ?c))"),
+    ];
+    let mut runner = Runner::default().with_egraph(egraph).run(&rules);
+    runner.egraph.check("(pred (path 1 4))");
+    runner.egraph.check("(pred (path 2 3))");
+    runner.egraph.check_not("(pred (path 4 1))");
+    runner.egraph.check_not("(pred (path 3 1))");
+}
+
+#[test]
+fn ctx_transfer() {
+    let mut egraph = EGraph::<Lang, ()>::default();
+    egraph.assert("(lte ctx1 ctx2)");
+    egraph.assert("(lte ctx2 ctx2)");
+    egraph.assert("(lte ctx1 ctx1)");
+    let x2 = egraph.add_expr(&"(tag x ctx2)".parse().unwrap());
+    let y2 = egraph.add_expr(&"(tag y ctx2)".parse().unwrap());
+    let z2 = egraph.add_expr(&"(tag z ctx2)".parse().unwrap());
+
+    let x1 = egraph.add_expr(&"(tag x ctx1)".parse().unwrap());
+    let y1 = egraph.add_expr(&"(tag y ctx1)".parse().unwrap());
+    let z1 = egraph.add_expr(&"(tag z ctx2)".parse().unwrap());
+    egraph.union(x1, y1);
+    egraph.union(y2, z2);
+    let rules = vec![
+        rewrite!("context-transfer"; "?x = (tag ?a ?ctx1) = (tag ?b ?ctx1), ?t = true = (lte ?ctx1 ?ctx2), ?a1 = (tag ?a ?ctx2), ?b1 = (tag ?b ?ctx2)" |- "?a1 = ?b1"),
+    ];
+    let runner = Runner::default().with_egraph(egraph).run(&rules);
+    assert_eq!(runner.egraph.find(x1), runner.egraph.find(y1));
+    assert_eq!(runner.egraph.find(y2), runner.egraph.find(z2));
+
+    assert_eq!(runner.egraph.find(x2), runner.egraph.find(y2));
+    assert_eq!(runner.egraph.find(x2), runner.egraph.find(z2));
+
+    assert!(runner.egraph.find(y1) != runner.egraph.find(z1));
+    assert!(runner.egraph.find(x1) != runner.egraph.find(z1));
 }

--- a/tests/datalog.rs
+++ b/tests/datalog.rs
@@ -1,0 +1,47 @@
+use egg::*;
+
+define_language! {
+    enum Lang {
+        "true" = True,
+        Int(i32),
+        Relation(Symbol, Box<[Id]>),
+    }
+}
+
+trait DatalogExtTrait {
+    fn assert(&mut self, s: &str);
+    fn check(&mut self, s: &str);
+}
+
+impl DatalogExtTrait for EGraph<Lang, ()> {
+    fn assert(&mut self, s: &str) {
+        let true_id = self.add(Lang::True);
+        for e in s.split(',') {
+            let exp = e.trim().parse().unwrap();
+            let id = self.add_expr(&exp);
+            self.union(true_id, id);
+        }
+    }
+
+    fn check(&mut self, s: &str) {
+        let true_id = self.add(Lang::True);
+        for e in s.split(',') {
+            let exp = e.trim().parse().unwrap();
+            let id = self.add_expr(&exp);
+            assert_eq!(true_id, id, "{} is not true", e);
+        }
+    }
+}
+
+#[test]
+fn path() {
+    let mut egraph = EGraph::<Lang, ()>::default();
+    egraph.assert("(edge 1 2), (edge 2 3), (edge 3 4)");
+    let rules = vec![
+        rewrite!("base-case"; "?x = true = (edge ?a ?b)" ==> "?x = (path ?a ?b)"),
+        rewrite!("transitive"; "?x = true = (path ?a ?b) = (edge ?b ?c)" ==> "?x = (path ?a ?c)"),
+    ];
+
+    let mut runner = Runner::default().with_egraph(egraph).run(&rules);
+    runner.egraph.check("(path 1 4)");
+}

--- a/tests/datalog.rs
+++ b/tests/datalog.rs
@@ -72,5 +72,3 @@ fn path2() {
     runner.egraph.check_not("(pred (path 4 1))");
     runner.egraph.check_not("(pred (path 3 1))");
 }
-
-

--- a/tests/datalog.rs
+++ b/tests/datalog.rs
@@ -38,8 +38,8 @@ fn path() {
     let mut egraph = EGraph::<Lang, ()>::default();
     egraph.assert("(edge 1 2), (edge 2 3), (edge 3 4)");
     let rules = vec![
-        rewrite!("base-case"; "?x = true = (edge ?a ?b)" ==> "?x = (path ?a ?b)"),
-        rewrite!("transitive"; "?x = true = (path ?a ?b) = (edge ?b ?c)" ==> "?x = (path ?a ?c)"),
+        rewrite!("base-case"; "?x = true = (edge ?a ?b)" |- "?x = (path ?a ?b)"),
+        rewrite!("transitive"; "?x = true = (path ?a ?b) = (edge ?b ?c)" |- "?x = (path ?a ?c)"),
     ];
 
     let mut runner = Runner::default().with_egraph(egraph).run(&rules);

--- a/tests/datalog.rs
+++ b/tests/datalog.rs
@@ -48,8 +48,8 @@ fn path() {
     let mut egraph = EGraph::<Lang, ()>::default();
     egraph.assert("(edge 1 2), (edge 2 3), (edge 3 4)");
     let rules = vec![
-        rewrite!("base-case"; "?x = true = (edge ?a ?b)" |- "?x = (path ?a ?b)"),
-        rewrite!("transitive"; "?x = true = (path ?a ?b) = (edge ?b ?c)" |- "?x = (path ?a ?c)"),
+        multi_rewrite!("base-case"; "?x = true = (edge ?a ?b)" => "?x = (path ?a ?b)"),
+        multi_rewrite!("transitive"; "?x = true = (path ?a ?b) = (edge ?b ?c)" => "?x = (path ?a ?c)"),
     ];
 
     let mut runner = Runner::default().with_egraph(egraph).run(&rules);
@@ -63,8 +63,8 @@ fn path2() {
     let mut egraph = EGraph::<Lang, ()>::default();
     egraph.assert("(edge 1 2), (edge 2 3), (edge 3 4), (edge 1 4)");
     let rules = vec![
-        rewrite!("base-case"; "?x = (edge ?a ?b), ?t = true" |- "?t = (pred (path ?a ?b))"),
-        rewrite!("transitive"; "?x = (path ?a ?b), ?y = (edge ?b ?c), ?t = true" |- "?t = (pred (path ?a ?c))"),
+        multi_rewrite!("base-case"; "?x = (edge ?a ?b), ?t = true" => "?t = (pred (path ?a ?b))"),
+        multi_rewrite!("transitive"; "?x = (path ?a ?b), ?y = (edge ?b ?c), ?t = true" => "?t = (pred (path ?a ?c))"),
     ];
     let mut runner = Runner::default().with_egraph(egraph).run(&rules);
     runner.egraph.check("(pred (path 1 4))");


### PR DESCRIPTION
Multipatterns are multiple possibly disjoint patterns to seek out in a search process. They are distinct from guards in that they may bind new variables. This pull request attempts to implement somewhat efficient multipatterns in a backwards compatible way.
The pattern compiler can remain mostly as is. Compiler state about what patterns are where in the subst map needs to be retained between each single pattern compilation.
Multipatterns require changes to the abstract machine because scanning for roots of the 2nd pattern onwards becomes required.
Extending the interface to be able to give pattern names to the root of the pattern itself enables significant extra modelling power. Note that labelled multipatterns allows one to implement efficient manual scheduling of search even for single patterns via flattening or breaking the pattern trees up.

This PR is still a work in progress, but examples can be found in the [`datalog.rs`](https://github.com/philzook58/egg/blob/multipattern2/tests/datalog.rs) test. The syntax for creating multipatterns might change, but it looks this currently:
```rust
    let rules = vec![
        multi_rewrite!("base-case"; "?x = true = (edge ?a ?b)" => "?x = (path ?a ?b)"),
        multi_rewrite!("transitive"; "?x = true = (path ?a ?b) = (edge ?b ?c)" => "?x = (path ?a ?c)"),
    ];
```

Closes #39 