### PR TITLE
Refactoring functions on finite sets example

### DIFF
--- a/tests/finset.rs
+++ b/tests/finset.rs
@@ -1,0 +1,167 @@
+use egg::*;
+
+// http://chadbrewbaker.github.io/algebra/haskell/functional/programming/2016/01/27/algebraRules.html
+// Emily Reihl, Category Theory in Context example 1.4.9 
+
+define_language! {
+    enum Prop {
+        Bool(bool),           // sets A, B
+        "^" = Exp([Id; 2]), // set of functions A -> B  , denoted B^A
+        "+" = Or([Id; 2]),  // disjoint union of A, B 
+        "*" = And([Id; 2]), // Cartesian product of A,B
+        Symbol(Symbol),
+    }
+}
+
+type EGraph = egg::EGraph<Prop, ConstantFold>;
+type Rewrite = egg::Rewrite<Prop, ConstantFold>;
+
+#[derive(Default)]
+struct ConstantFold;
+impl Analysis<Prop> for ConstantFold {
+    type Data = Option<(bool, PatternAst<Prop>)>;
+    fn merge(&mut self, to: &mut Self::Data, from: Self::Data) -> DidMerge {
+        merge_max(to, from)
+    }
+
+    fn make(egraph: &EGraph, enode: &Prop) -> Self::Data {
+        let x = |i: &Id| egraph[*i].data.as_ref().map(|c| c.0);
+        let result = match enode {
+            Prop::Bool(c) => Some((*c, c.to_string().parse().unwrap())),
+            Prop::Symbol(_) => None,
+            Prop::And([a, b]) => Some((
+                x(a)? && x(b)?,
+                format!("(& {} {})", x(a)?, x(b)?).parse().unwrap(),
+            )),
+            Prop::Not(a) => Some((!x(a)?, format!("(~ {})", x(a)?).parse().unwrap())),
+            Prop::Or([a, b]) => Some((
+                x(a)? || x(b)?,
+                format!("(| {} {})", x(a)?, x(b)?).parse().unwrap(),
+            )),
+            Prop::Implies([a, b]) => Some((
+                x(a)? || !x(b)?,
+                format!("(-> {} {})", x(a)?, x(b)?).parse().unwrap(),
+            )),
+        };
+        println!("Make: {:?} -> {:?}", enode, result);
+        result
+    }
+
+    fn modify(egraph: &mut EGraph, id: Id) {
+        if let Some(c) = egraph[id].data.clone() {
+            egraph.union_instantiations(
+                &c.1,
+                &c.0.to_string().parse().unwrap(),
+                &Default::default(),
+                "analysis".to_string(),
+            );
+        }
+    }
+}
+
+macro_rules! rule {
+    ($name:ident, $left:literal, $right:literal) => {
+        #[allow(dead_code)]
+        fn $name() -> Rewrite {
+            rewrite!(stringify!($name); $left => $right)
+        }
+    };
+    ($name:ident, $name2:ident, $left:literal, $right:literal) => {
+        rule!($name, $left, $right);
+        rule!($name2, $right, $left);
+    };
+}
+
+rule! {def_imply, def_imply_flip,   "(-> ?a ?b)",       "(| (~ ?a) ?b)"          }
+rule! {double_neg, double_neg_flip,  "(~ (~ ?a))",       "?a"                     }
+rule! {assoc_or,    "(| ?a (| ?b ?c))", "(| (| ?a ?b) ?c)"       }
+rule! {dist_and_or, "(& ?a (| ?b ?c))", "(| (& ?a ?b) (& ?a ?c))"}
+rule! {dist_or_and, "(| ?a (& ?b ?c))", "(& (| ?a ?b) (| ?a ?c))"}
+rule! {comm_or,     "(| ?a ?b)",        "(| ?b ?a)"              }
+rule! {comm_and,    "(& ?a ?b)",        "(& ?b ?a)"              }
+rule! {lem,         "(| ?a (~ ?a))",    "true"                      }
+rule! {or_true,     "(| ?a true)",         "true"                      }
+rule! {and_true,    "(& ?a true)",         "?a"                     }
+rule! {contrapositive, "(-> ?a ?b)",    "(-> (~ ?b) (~ ?a))"     }
+rule! {lem_imply, "(& (-> ?a ?b) (-> (~ ?a) ?c))", "(| ?b ?c)"}
+
+fn prove_something(name: &str, start: &str, rewrites: &[Rewrite], goals: &[&str]) {
+    let _ = env_logger::builder().is_test(true).try_init();
+    println!("Proving {}", name);
+
+    let start_expr: RecExpr<_> = start.parse().unwrap();
+    let goal_exprs: Vec<RecExpr<_>> = goals.iter().map(|g| g.parse().unwrap()).collect();
+
+    let egraph = Runner::default()
+        .with_iter_limit(20)
+        .with_node_limit(5_000)
+        .with_expr(&start_expr)
+        .run(rewrites)
+        .egraph;
+
+    for (i, (goal_expr, goal_str)) in goal_exprs.iter().zip(goals).enumerate() {
+        println!("Trying to prove goal {}: {}", i, goal_str);
+        let equivs = egraph.equivs(&start_expr, &goal_expr);
+        if equivs.is_empty() {
+            panic!("Couldn't prove goal {}: {}", i, goal_str);
+        }
+    }
+}
+
+#[test]
+fn prove_contrapositive() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let rules = &[def_imply(), def_imply_flip(), double_neg_flip(), comm_or()];
+    prove_something(
+        "contrapositive",
+        "(-> x y)",
+        rules,
+        &[
+            "(-> x y)",
+            "(| (~ x) y)",
+            "(| (~ x) (~ (~ y)))",
+            "(| (~ (~ y)) (~ x))",
+            "(-> (~ y) (~ x))",
+        ],
+    );
+}
+
+#[test]
+fn prove_chain() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let rules = &[
+        // rules needed for contrapositive
+        def_imply(),
+        def_imply_flip(),
+        double_neg_flip(),
+        comm_or(),
+        // and some others
+        comm_and(),
+        lem_imply(),
+    ];
+    prove_something(
+        "chain",
+        "(& (-> x y) (-> y z))",
+        rules,
+        &[
+            "(& (-> x y) (-> y z))",
+            "(& (-> (~ y) (~ x)) (-> y z))",
+            "(& (-> y z)         (-> (~ y) (~ x)))",
+            "(| z (~ x))",
+            "(| (~ x) z)",
+            "(-> x z)",
+        ],
+    );
+}
+
+#[test]
+fn const_fold() {
+    let start = "(| (& false true) (& true false))";
+    let start_expr = start.parse().unwrap();
+    let end = "false";
+    let end_expr = end.parse().unwrap();
+    let mut eg = EGraph::default();
+    eg.add_expr(&start_expr);
+    eg.rebuild();
+    assert!(!eg.equivs(&start_expr, &end_expr).is_empty());
+}

--- a/tests/finset.rs
+++ b/tests/finset.rs
@@ -165,6 +165,14 @@ pub fn rules() -> Vec<Rewrite> { vec![
     rw!("assoc-add"; "(+ ?a (+ ?b ?c))" => "(+ (+ ?a ?b) ?c)"),
     rw!("assoc-mul"; "(* ?a (* ?b ?c))" => "(* (* ?a ?b) ?c)"),
 
+    rw!("distribute"; "(* ?a (+ ?b ?c))"        => "(+ (* ?a ?b) (* ?a ?c))"),
+    rw!("factor"    ; "(+ (* ?a ?b) (* ?a ?c))" => "(* ?a (+ ?b ?c))"),
+    rw!("pow-mul"; "(* (pow ?a ?b) (pow ?a ?c))" => "(pow ?a (+ ?b ?c))"),
+    rw!("curry"; "(pow (pow ?a ?m) ?n)" => "(pow ?a (* ?m ?n))"),
+    rw!("co-curry"; "(* (pow ?a  ?m) (pow ?b  ?m)  )" => "(pow (* ?a ?b) ?m )"),
+    rw!("domain-split"; "(* (pow ?a  ?m) (pow ?a  ?n)  )" => "(pow a (+ ?m ?n))"), 
+
+
    // rw!("sub-canon"; "(- ?a ?b)" => "(+ ?a (* -1 ?b))"),
    // rw!("div-canon"; "(/ ?a ?b)" => "(* ?a (pow ?b -1))" if is_not_zero("?b")),
     // rw!("canon-sub"; "(+ ?a (* -1 ?b))"   => "(- ?a ?b)"),
@@ -180,10 +188,7 @@ pub fn rules() -> Vec<Rewrite> { vec![
    // rw!("cancel-sub"; "(- ?a ?a)" => "0"),
   //  rw!("cancel-div"; "(/ ?a ?a)" => "1" if is_not_zero("?a")),
 
-    rw!("distribute"; "(* ?a (+ ?b ?c))"        => "(+ (* ?a ?b) (* ?a ?c))"),
-    rw!("factor"    ; "(+ (* ?a ?b) (* ?a ?c))" => "(* ?a (+ ?b ?c))"),
-
-    rw!("pow-mul"; "(* (pow ?a ?b) (pow ?a ?c))" => "(pow ?a (+ ?b ?c))"),
+  
  //   rw!("pow0"; "(pow ?x 0)" => "1"
  //       if is_not_zero("?x")),
  //   rw!("pow1"; "(pow ?x 1)" => "?x"),
@@ -307,9 +312,9 @@ egg::test_fn! {
     "(* x (- (* 3 x) 14))"
 }
 */
-//egg::test_fn! {
-//    integ_one, rules(), "(i 1 x)" => "x"
-//}
+egg::test_fn! {
+    integ_one, rules(), "(x)" => "x"
+}
 
 //egg::test_fn! {
 //    integ_sin, rules(), "(i (cos x) x)" => "(sin x)"
@@ -348,6 +353,7 @@ fn assoc_mul_saturates() {
 #[test]
 fn math_ematching_bench() {
     let exprs = &[
+        "(* ?a (* ?b ?c))",
     //    "(i (ln x) x)",
     //    "(i (+ x (cos x)) x)",
    //     "(i (* (cos x) x) x)",
@@ -392,5 +398,5 @@ fn math_ematching_bench() {
        // "(- (* ?a (i ?b ?x)) (i (* (d ?x ?a) (i ?b ?x)) ?x))",
     ];
 
-    egg::test::bench_egraph("math", rules(), exprs, extra_patterns);
+    egg::test::bench_egraph("finset", rules(), exprs, extra_patterns);
 }

--- a/tests/finset.rs
+++ b/tests/finset.rs
@@ -8,7 +8,10 @@ pub type Constant = NotNan<f64>;
 
 // http://chadbrewbaker.github.io/algebra/haskell/functional/programming/2016/01/27/algebraRules.html
 // Emily Reihl, Category Theory in Context example 1.4.9 
+
+
 // TODO , after this extend to combinatorial species https://github.com/akc/spe
+// that will allow for stuff like "Seven Trees in One", Andreas Blas https://arxiv.org/abs/math/9405205 
 
 define_language! {
     pub enum Math {

--- a/tests/finset.rs
+++ b/tests/finset.rs
@@ -1,167 +1,385 @@
-use egg::*;
+use egg::{rewrite as rw, *};
+use ordered_float::NotNan;
+
+pub type EGraph = egg::EGraph<Math, ConstantFold>;
+pub type Rewrite = egg::Rewrite<Math, ConstantFold>;
+
+pub type Constant = NotNan<f64>;
 
 // http://chadbrewbaker.github.io/algebra/haskell/functional/programming/2016/01/27/algebraRules.html
 // Emily Reihl, Category Theory in Context example 1.4.9 
 
+
 define_language! {
-    enum Prop {
-        Bool(bool),           // sets A, B
-        "^" = Exp([Id; 2]), // set of functions A -> B  , denoted B^A
-        "+" = Or([Id; 2]),  // disjoint union of A, B 
-        "*" = And([Id; 2]), // Cartesian product of A,B
+    pub enum Math {
+  //      "d" = Diff([Id; 2]),
+  //      "i" = Integral([Id; 2]),
+
+        "+" = Add([Id; 2]),
+        "-" = Sub([Id; 2]),
+        "*" = Mul([Id; 2]),
+        "/" = Div([Id; 2]),
+        "pow" = Pow([Id; 2]),
+        "ln" = Ln(Id),
+        "sqrt" = Sqrt(Id),
+
+        "sin" = Sin(Id),
+        "cos" = Cos(Id),
+
+        Constant(Constant),
         Symbol(Symbol),
     }
 }
 
-type EGraph = egg::EGraph<Prop, ConstantFold>;
-type Rewrite = egg::Rewrite<Prop, ConstantFold>;
+// You could use egg::AstSize, but this is useful for debugging, since
+// it will really try to get rid of the Diff operator
+pub struct MathCostFn;
+impl egg::CostFunction<Math> for MathCostFn {
+    type Cost = usize;
+    fn cost<C>(&mut self, enode: &Math, mut costs: C) -> Self::Cost
+    where
+        C: FnMut(Id) -> Self::Cost,
+    {
+        let op_cost = match enode {
+     //       Math::Diff(..) => 100,
+     //       Math::Integral(..) => 100,
+            _ => 1,
+        };
+        enode.fold(op_cost, |sum, i| sum + costs(i))
+    }
+}
 
 #[derive(Default)]
-struct ConstantFold;
-impl Analysis<Prop> for ConstantFold {
-    type Data = Option<(bool, PatternAst<Prop>)>;
-    fn merge(&mut self, to: &mut Self::Data, from: Self::Data) -> DidMerge {
-        merge_max(to, from)
+pub struct ConstantFold;
+impl Analysis<Math> for ConstantFold {
+    type Data = Option<(Constant, PatternAst<Math>)>;
+
+    fn make(egraph: &EGraph, enode: &Math) -> Self::Data {
+        let x = |i: &Id| egraph[*i].data.as_ref().map(|d| d.0);
+        Some(match enode {
+            Math::Constant(c) => (*c, format!("{}", c).parse().unwrap()),
+            Math::Add([a, b]) => (
+                x(a)? + x(b)?,
+                format!("(+ {} {})", x(a)?, x(b)?).parse().unwrap(),
+            ),
+            Math::Sub([a, b]) => (
+                x(a)? - x(b)?,
+                format!("(- {} {})", x(a)?, x(b)?).parse().unwrap(),
+            ),
+            Math::Mul([a, b]) => (
+                x(a)? * x(b)?,
+                format!("(* {} {})", x(a)?, x(b)?).parse().unwrap(),
+            ),
+            Math::Div([a, b]) if x(b) != Some(NotNan::new(0.0).unwrap()) => (
+                x(a)? / x(b)?,
+                format!("(/ {} {})", x(a)?, x(b)?).parse().unwrap(),
+            ),
+            _ => return None,
+        })
     }
 
-    fn make(egraph: &EGraph, enode: &Prop) -> Self::Data {
-        let x = |i: &Id| egraph[*i].data.as_ref().map(|c| c.0);
-        let result = match enode {
-            Prop::Bool(c) => Some((*c, c.to_string().parse().unwrap())),
-            Prop::Symbol(_) => None,
-            Prop::And([a, b]) => Some((
-                x(a)? && x(b)?,
-                format!("(& {} {})", x(a)?, x(b)?).parse().unwrap(),
-            )),
-            Prop::Not(a) => Some((!x(a)?, format!("(~ {})", x(a)?).parse().unwrap())),
-            Prop::Or([a, b]) => Some((
-                x(a)? || x(b)?,
-                format!("(| {} {})", x(a)?, x(b)?).parse().unwrap(),
-            )),
-            Prop::Implies([a, b]) => Some((
-                x(a)? || !x(b)?,
-                format!("(-> {} {})", x(a)?, x(b)?).parse().unwrap(),
-            )),
-        };
-        println!("Make: {:?} -> {:?}", enode, result);
-        result
+    fn merge(&mut self, a: &mut Self::Data, b: Self::Data) -> DidMerge {
+        match (a.as_mut(), &b) {
+            (None, None) => DidMerge(false, false),
+            (None, Some(_)) => {
+                *a = b;
+                DidMerge(true, false)
+            }
+            (Some(_), None) => DidMerge(false, true),
+            (Some(_), Some(_)) => DidMerge(false, false),
+        }
+        // if a.is_none() && b.is_some() {
+        //     *a = b
+        // }
+        // cmp
     }
 
     fn modify(egraph: &mut EGraph, id: Id) {
-        if let Some(c) = egraph[id].data.clone() {
-            egraph.union_instantiations(
-                &c.1,
-                &c.0.to_string().parse().unwrap(),
-                &Default::default(),
-                "analysis".to_string(),
-            );
+        let class = egraph[id].clone();
+        if let Some((c, pat)) = class.data {
+            if egraph.are_explanations_enabled() {
+                egraph.union_instantiations(
+                    &pat,
+                    &format!("{}", c).parse().unwrap(),
+                    &Default::default(),
+                    "constant_fold".to_string(),
+                );
+            } else {
+                let added = egraph.add(Math::Constant(c));
+                egraph.union(id, added);
+            }
+            // to not prune, comment this out
+            egraph[id].nodes.retain(|n| n.is_leaf());
+
+            #[cfg(debug_assertions)]
+            egraph[id].assert_unique_leaves();
         }
     }
 }
 
-macro_rules! rule {
-    ($name:ident, $left:literal, $right:literal) => {
-        #[allow(dead_code)]
-        fn $name() -> Rewrite {
-            rewrite!(stringify!($name); $left => $right)
-        }
-    };
-    ($name:ident, $name2:ident, $left:literal, $right:literal) => {
-        rule!($name, $left, $right);
-        rule!($name2, $right, $left);
-    };
+fn is_const_or_distinct_var(v: &str, w: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
+    let v = v.parse().unwrap();
+    let w = w.parse().unwrap();
+    move |egraph, _, subst| {
+        egraph.find(subst[v]) != egraph.find(subst[w])
+            && (egraph[subst[v]].data.is_some()
+                || egraph[subst[v]]
+                    .nodes
+                    .iter()
+                    .any(|n| matches!(n, Math::Symbol(..))))
+    }
 }
 
-rule! {def_imply, def_imply_flip,   "(-> ?a ?b)",       "(| (~ ?a) ?b)"          }
-rule! {double_neg, double_neg_flip,  "(~ (~ ?a))",       "?a"                     }
-rule! {assoc_or,    "(| ?a (| ?b ?c))", "(| (| ?a ?b) ?c)"       }
-rule! {dist_and_or, "(& ?a (| ?b ?c))", "(| (& ?a ?b) (& ?a ?c))"}
-rule! {dist_or_and, "(| ?a (& ?b ?c))", "(& (| ?a ?b) (| ?a ?c))"}
-rule! {comm_or,     "(| ?a ?b)",        "(| ?b ?a)"              }
-rule! {comm_and,    "(& ?a ?b)",        "(& ?b ?a)"              }
-rule! {lem,         "(| ?a (~ ?a))",    "true"                      }
-rule! {or_true,     "(| ?a true)",         "true"                      }
-rule! {and_true,    "(& ?a true)",         "?a"                     }
-rule! {contrapositive, "(-> ?a ?b)",    "(-> (~ ?b) (~ ?a))"     }
-rule! {lem_imply, "(& (-> ?a ?b) (-> (~ ?a) ?c))", "(| ?b ?c)"}
+fn is_const(var: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
+    let var = var.parse().unwrap();
+    move |egraph, _, subst| egraph[subst[var]].data.is_some()
+}
 
-fn prove_something(name: &str, start: &str, rewrites: &[Rewrite], goals: &[&str]) {
-    let _ = env_logger::builder().is_test(true).try_init();
-    println!("Proving {}", name);
+fn is_sym(var: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
+    let var = var.parse().unwrap();
+    move |egraph, _, subst| {
+        egraph[subst[var]]
+            .nodes
+            .iter()
+            .any(|n| matches!(n, Math::Symbol(..)))
+    }
+}
 
-    let start_expr: RecExpr<_> = start.parse().unwrap();
-    let goal_exprs: Vec<RecExpr<_>> = goals.iter().map(|g| g.parse().unwrap()).collect();
-
-    let egraph = Runner::default()
-        .with_iter_limit(20)
-        .with_node_limit(5_000)
-        .with_expr(&start_expr)
-        .run(rewrites)
-        .egraph;
-
-    for (i, (goal_expr, goal_str)) in goal_exprs.iter().zip(goals).enumerate() {
-        println!("Trying to prove goal {}: {}", i, goal_str);
-        let equivs = egraph.equivs(&start_expr, &goal_expr);
-        if equivs.is_empty() {
-            panic!("Couldn't prove goal {}: {}", i, goal_str);
+fn is_not_zero(var: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
+    let var = var.parse().unwrap();
+    move |egraph, _, subst| {
+        if let Some(n) = &egraph[subst[var]].data {
+            *(n.0) != 0.0
+        } else {
+            true
         }
     }
 }
 
+#[rustfmt::skip]
+pub fn rules() -> Vec<Rewrite> { vec![
+    rw!("comm-add";  "(+ ?a ?b)"        => "(+ ?b ?a)"),
+    rw!("comm-mul";  "(* ?a ?b)"        => "(* ?b ?a)"),
+    rw!("assoc-add"; "(+ ?a (+ ?b ?c))" => "(+ (+ ?a ?b) ?c)"),
+    rw!("assoc-mul"; "(* ?a (* ?b ?c))" => "(* (* ?a ?b) ?c)"),
+
+    rw!("sub-canon"; "(- ?a ?b)" => "(+ ?a (* -1 ?b))"),
+    rw!("div-canon"; "(/ ?a ?b)" => "(* ?a (pow ?b -1))" if is_not_zero("?b")),
+    // rw!("canon-sub"; "(+ ?a (* -1 ?b))"   => "(- ?a ?b)"),
+    // rw!("canon-div"; "(* ?a (pow ?b -1))" => "(/ ?a ?b)" if is_not_zero("?b")),
+
+    rw!("zero-add"; "(+ ?a 0)" => "?a"),
+    rw!("zero-mul"; "(* ?a 0)" => "0"),
+    rw!("one-mul";  "(* ?a 1)" => "?a"),
+
+    rw!("add-zero"; "?a" => "(+ ?a 0)"),
+    rw!("mul-one";  "?a" => "(* ?a 1)"),
+
+    rw!("cancel-sub"; "(- ?a ?a)" => "0"),
+    rw!("cancel-div"; "(/ ?a ?a)" => "1" if is_not_zero("?a")),
+
+    rw!("distribute"; "(* ?a (+ ?b ?c))"        => "(+ (* ?a ?b) (* ?a ?c))"),
+    rw!("factor"    ; "(+ (* ?a ?b) (* ?a ?c))" => "(* ?a (+ ?b ?c))"),
+
+    rw!("pow-mul"; "(* (pow ?a ?b) (pow ?a ?c))" => "(pow ?a (+ ?b ?c))"),
+    rw!("pow0"; "(pow ?x 0)" => "1"
+        if is_not_zero("?x")),
+    rw!("pow1"; "(pow ?x 1)" => "?x"),
+    rw!("pow2"; "(pow ?x 2)" => "(* ?x ?x)"),
+    rw!("pow-recip"; "(pow ?x -1)" => "(/ 1 ?x)"
+        if is_not_zero("?x")),
+    rw!("recip-mul-div"; "(* ?x (/ 1 ?x))" => "1" if is_not_zero("?x")),
+
+   // rw!("d-variable"; "(d ?x ?x)" => "1" if is_sym("?x")),
+   // rw!("d-constant"; "(d ?x ?c)" => "0" if is_sym("?x") if is_const_or_distinct_var("?c", "?x")),
+
+    //rw!("d-add"; "(d ?x (+ ?a ?b))" => "(+ (d ?x ?a) (d ?x ?b))"),
+   // rw!("d-mul"; "(d ?x (* ?a ?b))" => "(+ (* ?a (d ?x ?b)) (* ?b (d ?x ?a)))"),
+
+  //  rw!("d-sin"; "(d ?x (sin ?x))" => "(cos ?x)"),
+  //  rw!("d-cos"; "(d ?x (cos ?x))" => "(* -1 (sin ?x))"),
+
+  //  rw!("d-ln"; "(d ?x (ln ?x))" => "(/ 1 ?x)" if is_not_zero("?x")),
+
+ /*   rw!("d-power";
+        "(d ?x (pow ?f ?g))" =>
+        "(* (pow ?f ?g)
+            (+ (* (d ?x ?f)
+                  (/ ?g ?f))
+               (* (d ?x ?g)
+                  (ln ?f))))"
+        if is_not_zero("?f")
+        if is_not_zero("?g")
+    ),
+*/
+//    rw!("i-one"; "(i 1 ?x)" => "?x"),
+//    rw!("i-power-const"; "(i (pow ?x ?c) ?x)" =>
+ //       "(/ (pow ?x (+ ?c 1)) (+ ?c 1))" if is_const("?c")),
+  //  rw!("i-cos"; "(i (cos ?x) ?x)" => "(sin ?x)"),
+  //  rw!("i-sin"; "(i (sin ?x) ?x)" => "(* -1 (cos ?x))"),
+  //  rw!("i-sum"; "(i (+ ?f ?g) ?x)" => "(+ (i ?f ?x) (i ?g ?x))"),
+  //  rw!("i-dif"; "(i (- ?f ?g) ?x)" => "(- (i ?f ?x) (i ?g ?x))"),
+  //  rw!("i-parts"; "(i (* ?a ?b) ?x)" =>
+  //      "(- (* ?a (i ?b ?x)) (i (* (d ?x ?a) (i ?b ?x)) ?x))"),
+]}
+
+egg::test_fn! {
+    math_associate_adds, [
+        rw!("comm-add"; "(+ ?a ?b)" => "(+ ?b ?a)"),
+        rw!("assoc-add"; "(+ ?a (+ ?b ?c))" => "(+ (+ ?a ?b) ?c)"),
+    ],
+    runner = Runner::default()
+        .with_iter_limit(7)
+        .with_scheduler(SimpleScheduler),
+    "(+ 1 (+ 2 (+ 3 (+ 4 (+ 5 (+ 6 7))))))"
+    =>
+    "(+ 7 (+ 6 (+ 5 (+ 4 (+ 3 (+ 2 1))))))"
+    @check |r: Runner<Math, ()>| assert_eq!(r.egraph.number_of_classes(), 127)
+}
+
+egg::test_fn! {
+    #[should_panic(expected = "Could not prove goal 0")]
+    math_fail, rules(),
+    "(+ x y)" => "(/ x y)"
+}
+
+egg::test_fn! {math_simplify_add, rules(), "(+ x (+ x (+ x x)))" => "(* 4 x)" }
+egg::test_fn! {math_powers, rules(), "(* (pow 2 x) (pow 2 y))" => "(pow 2 (+ x y))"}
+
+egg::test_fn! {
+    math_simplify_const, rules(),
+    "(+ 1 (- a (* (- 2 1) a)))" => "1"
+}
+
+egg::test_fn! {
+    math_simplify_root, rules(),
+    runner = Runner::default().with_node_limit(75_000),
+    r#"
+    (/ 1
+       (- (/ (+ 1 (sqrt five))
+             2)
+          (/ (- 1 (sqrt five))
+             2)))"#
+    =>
+    "(/ 1 (sqrt five))"
+}
+
+egg::test_fn! {
+    math_simplify_factor, rules(),
+    "(* (+ x 3) (+ x 1))"
+    =>
+    "(+ (+ (* x x) (* 4 x)) 3)"
+}
+
+//egg::test_fn! {math_diff_same,      rules(), "(d x x)" => "1"}
+//egg::test_fn! {math_diff_different, rules(), "(d x y)" => "0"}
+//egg::test_fn! {math_diff_simple1,   rules(), "(d x (+ 1 (* 2 x)))" => "2"}
+//egg::test_fn! {math_diff_simple2,   rules(), "(d x (+ 1 (* y x)))" => "y"}
+//egg::test_fn! {math_diff_ln,        rules(), "(d x (ln x))" => "(/ 1 x)"}
+
+//egg::test_fn! {
+//    diff_power_simple, rules(),
+//    "(d x (pow x 3))" => "(* 3 (pow x 2))"
+//}
+
+/*
+egg::test_fn! {
+    diff_power_harder, rules(),
+    runner = Runner::default()
+        .with_time_limit(std::time::Duration::from_secs(10))
+        .with_iter_limit(60)
+        .with_node_limit(100_000)
+        .with_explanations_enabled()
+        // HACK this needs to "see" the end expression
+        .with_expr(&"(* x (- (* 3 x) 14))".parse().unwrap()),
+    "(d x (- (pow x 3) (* 7 (pow x 2))))"
+    =>
+    "(* x (- (* 3 x) 14))"
+}
+*/
+//egg::test_fn! {
+//    integ_one, rules(), "(i 1 x)" => "x"
+//}
+
+//egg::test_fn! {
+//    integ_sin, rules(), "(i (cos x) x)" => "(sin x)"
+//}
+
+//egg::test_fn! {
+//    integ_x, rules(), "(i (pow x 1) x)" => "(/ (pow x 2) 2)"
+//}
+
+//egg::test_fn! {
+ //   integ_part1, rules(), "(i (* x (cos x)) x)" => "(+ (* x (sin x)) (cos x))"
+//}
+
+//egg::test_fn! {
+ //   integ_part2, rules(),
+ //   "(i (* (cos x) x) x)" => "(+ (* x (sin x)) (cos x))"
+//}
+
+//egg::test_fn! {
+//    integ_part3, rules(), "(i (ln x) x)" => "(- (* x (ln x)) x)"
+//}
+
 #[test]
-fn prove_contrapositive() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let rules = &[def_imply(), def_imply_flip(), double_neg_flip(), comm_or()];
-    prove_something(
-        "contrapositive",
-        "(-> x y)",
-        rules,
-        &[
-            "(-> x y)",
-            "(| (~ x) y)",
-            "(| (~ x) (~ (~ y)))",
-            "(| (~ (~ y)) (~ x))",
-            "(-> (~ y) (~ x))",
-        ],
-    );
+fn assoc_mul_saturates() {
+    let expr: RecExpr<Math> = "(* x 1)".parse().unwrap();
+
+    let runner: Runner<Math, ConstantFold> = Runner::default()
+        .with_iter_limit(3)
+        .with_expr(&expr)
+        .run(&rules());
+
+    assert!(matches!(runner.stop_reason, Some(StopReason::Saturated)));
 }
 
 #[test]
-fn prove_chain() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let rules = &[
-        // rules needed for contrapositive
-        def_imply(),
-        def_imply_flip(),
-        double_neg_flip(),
-        comm_or(),
-        // and some others
-        comm_and(),
-        lem_imply(),
+fn math_ematching_bench() {
+    let exprs = &[
+    //    "(i (ln x) x)",
+    //    "(i (+ x (cos x)) x)",
+   //     "(i (* (cos x) x) x)",
+    //    "(d x (+ 1 (* 2 x)))",
+    //    "(d x (- (pow x 3) (* 7 (pow x 2))))",
+        "(+ (* y (+ x y)) (- (+ x 2) (+ x x)))",
+        "(/ 1 (- (/ (+ 1 (sqrt five)) 2) (/ (- 1 (sqrt five)) 2)))",
     ];
-    prove_something(
-        "chain",
-        "(& (-> x y) (-> y z))",
-        rules,
-        &[
-            "(& (-> x y) (-> y z))",
-            "(& (-> (~ y) (~ x)) (-> y z))",
-            "(& (-> y z)         (-> (~ y) (~ x)))",
-            "(| z (~ x))",
-            "(| (~ x) z)",
-            "(-> x z)",
-        ],
-    );
-}
 
-#[test]
-fn const_fold() {
-    let start = "(| (& false true) (& true false))";
-    let start_expr = start.parse().unwrap();
-    let end = "false";
-    let end_expr = end.parse().unwrap();
-    let mut eg = EGraph::default();
-    eg.add_expr(&start_expr);
-    eg.rebuild();
-    assert!(!eg.equivs(&start_expr, &end_expr).is_empty());
+    let extra_patterns = &[
+        "(+ ?a (+ ?b ?c))",
+        "(+ (+ ?a ?b) ?c)",
+        "(* ?a (* ?b ?c))",
+        "(* (* ?a ?b) ?c)",
+        "(+ ?a (* -1 ?b))",
+        "(* ?a (pow ?b -1))",
+        "(* ?a (+ ?b ?c))",
+        "(pow ?a (+ ?b ?c))",
+        "(+ (* ?a ?b) (* ?a ?c))",
+        "(* (pow ?a ?b) (pow ?a ?c))",
+        "(* ?x (/ 1 ?x))",
+     //   "(d ?x (+ ?a ?b))",
+      //  "(+ (d ?x ?a) (d ?x ?b))",
+     //   "(d ?x (* ?a ?b))",
+     //   "(+ (* ?a (d ?x ?b)) (* ?b (d ?x ?a)))",
+     //   "(d ?x (sin ?x))",
+     //   "(d ?x (cos ?x))",
+        "(* -1 (sin ?x))",
+        "(* -1 (cos ?x))",
+     //   "(i (cos ?x) ?x)",
+     //   "(i (sin ?x) ?x)",
+      //  "(d ?x (ln ?x))",
+     //   "(d ?x (pow ?f ?g))",
+      //  "(* (pow ?f ?g) (+ (* (d ?x ?f) (/ ?g ?f)) (* (d ?x ?g) (ln ?f))))",
+      //  "(i (pow ?x ?c) ?x)",
+        "(/ (pow ?x (+ ?c 1)) (+ ?c 1))",
+      //  "(i (+ ?f ?g) ?x)",
+      //  "(i (- ?f ?g) ?x)",
+      //  "(+ (i ?f ?x) (i ?g ?x))",
+      //  "(- (i ?f ?x) (i ?g ?x))",
+      //  "(i (* ?a ?b) ?x)",
+       // "(- (* ?a (i ?b ?x)) (i (* (d ?x ?a) (i ?b ?x)) ?x))",
+    ];
+
+    egg::test::bench_egraph("math", rules(), exprs, extra_patterns);
 }

--- a/tests/finset.rs
+++ b/tests/finset.rs
@@ -16,15 +16,15 @@ define_language! {
   //      "i" = Integral([Id; 2]),
 
         "+" = Add([Id; 2]),
-        "-" = Sub([Id; 2]),
+     //   "-" = Sub([Id; 2]),
         "*" = Mul([Id; 2]),
         "/" = Div([Id; 2]),
         "pow" = Pow([Id; 2]),
         "ln" = Ln(Id),
         "sqrt" = Sqrt(Id),
 
-        "sin" = Sin(Id),
-        "cos" = Cos(Id),
+      //  "sin" = Sin(Id),
+     //   "cos" = Cos(Id),
 
         Constant(Constant),
         Symbol(Symbol),
@@ -62,10 +62,10 @@ impl Analysis<Math> for ConstantFold {
                 x(a)? + x(b)?,
                 format!("(+ {} {})", x(a)?, x(b)?).parse().unwrap(),
             ),
-            Math::Sub([a, b]) => (
-                x(a)? - x(b)?,
-                format!("(- {} {})", x(a)?, x(b)?).parse().unwrap(),
-            ),
+         //   Math::Sub([a, b]) => (
+         //       x(a)? - x(b)?,
+         //       format!("(- {} {})", x(a)?, x(b)?).parse().unwrap(),
+         //   ),
             Math::Mul([a, b]) => (
                 x(a)? * x(b)?,
                 format!("(* {} {})", x(a)?, x(b)?).parse().unwrap(),
@@ -163,7 +163,7 @@ pub fn rules() -> Vec<Rewrite> { vec![
     rw!("assoc-add"; "(+ ?a (+ ?b ?c))" => "(+ (+ ?a ?b) ?c)"),
     rw!("assoc-mul"; "(* ?a (* ?b ?c))" => "(* (* ?a ?b) ?c)"),
 
-    rw!("sub-canon"; "(- ?a ?b)" => "(+ ?a (* -1 ?b))"),
+   // rw!("sub-canon"; "(- ?a ?b)" => "(+ ?a (* -1 ?b))"),
     rw!("div-canon"; "(/ ?a ?b)" => "(* ?a (pow ?b -1))" if is_not_zero("?b")),
     // rw!("canon-sub"; "(+ ?a (* -1 ?b))"   => "(- ?a ?b)"),
     // rw!("canon-div"; "(* ?a (pow ?b -1))" => "(/ ?a ?b)" if is_not_zero("?b")),
@@ -175,7 +175,7 @@ pub fn rules() -> Vec<Rewrite> { vec![
     rw!("add-zero"; "?a" => "(+ ?a 0)"),
     rw!("mul-one";  "?a" => "(* ?a 1)"),
 
-    rw!("cancel-sub"; "(- ?a ?a)" => "0"),
+   // rw!("cancel-sub"; "(- ?a ?a)" => "0"),
     rw!("cancel-div"; "(/ ?a ?a)" => "1" if is_not_zero("?a")),
 
     rw!("distribute"; "(* ?a (+ ?b ?c))"        => "(+ (* ?a ?b) (* ?a ?c))"),
@@ -246,11 +246,12 @@ egg::test_fn! {
 egg::test_fn! {math_simplify_add, rules(), "(+ x (+ x (+ x x)))" => "(* 4 x)" }
 egg::test_fn! {math_powers, rules(), "(* (pow 2 x) (pow 2 y))" => "(pow 2 (+ x y))"}
 
-egg::test_fn! {
-    math_simplify_const, rules(),
-    "(+ 1 (- a (* (- 2 1) a)))" => "1"
-}
+//egg::test_fn! {
+//    math_simplify_const, rules(),
+//    "(+ 1 (- a (* (- 2 1) a)))" => "1"
+//}
 
+/*
 egg::test_fn! {
     math_simplify_root, rules(),
     runner = Runner::default().with_node_limit(75_000),
@@ -263,7 +264,7 @@ egg::test_fn! {
     =>
     "(/ 1 (sqrt five))"
 }
-
+*/
 egg::test_fn! {
     math_simplify_factor, rules(),
     "(* (+ x 3) (+ x 1))"
@@ -342,8 +343,8 @@ fn math_ematching_bench() {
    //     "(i (* (cos x) x) x)",
     //    "(d x (+ 1 (* 2 x)))",
     //    "(d x (- (pow x 3) (* 7 (pow x 2))))",
-        "(+ (* y (+ x y)) (- (+ x 2) (+ x x)))",
-        "(/ 1 (- (/ (+ 1 (sqrt five)) 2) (/ (- 1 (sqrt five)) 2)))",
+    //    "(+ (* y (+ x y)) (- (+ x 2) (+ x x)))",
+    //    "(/ 1 (- (/ (+ 1 (sqrt five)) 2) (/ (- 1 (sqrt five)) 2)))",
     ];
 
     let extra_patterns = &[
@@ -351,8 +352,8 @@ fn math_ematching_bench() {
         "(+ (+ ?a ?b) ?c)",
         "(* ?a (* ?b ?c))",
         "(* (* ?a ?b) ?c)",
-        "(+ ?a (* -1 ?b))",
-        "(* ?a (pow ?b -1))",
+      //  "(+ ?a (* -1 ?b))",
+      //  "(* ?a (pow ?b -1))",
         "(* ?a (+ ?b ?c))",
         "(pow ?a (+ ?b ?c))",
         "(+ (* ?a ?b) (* ?a ?c))",
@@ -364,8 +365,8 @@ fn math_ematching_bench() {
      //   "(+ (* ?a (d ?x ?b)) (* ?b (d ?x ?a)))",
      //   "(d ?x (sin ?x))",
      //   "(d ?x (cos ?x))",
-        "(* -1 (sin ?x))",
-        "(* -1 (cos ?x))",
+     //   "(* -1 (sin ?x))",
+      //  "(* -1 (cos ?x))",
      //   "(i (cos ?x) ?x)",
      //   "(i (sin ?x) ?x)",
       //  "(d ?x (ln ?x))",


### PR DESCRIPTION
WIP

See:
http://chadbrewbaker.github.io/algebra/haskell/functional/programming/2016/01/27/algebraRules.html
Emily Reihl, Category Theory in Context example 1.4.9 

This is what "HoTT" is in practice for functions over enum (small cardinality) types. 

- [ ] remove commented code.
- [ ] add in more tests
- [ ] add primality/factoring based on size of set refactoring rules 
- [ ] follow up on gk suggestion to look at https://agda.github.io/agda-stdlib/Data.Product.Algebra.html  for anything missed.

I'm debating if I should add unit and null constants.

