### PR TITLE
Add an unsound method to easily merge to eclasses when explanations are enabled

### DIFF
--- a/tests/math.rs
+++ b/tests/math.rs
@@ -329,6 +329,30 @@ fn assoc_mul_saturates() {
     assert!(matches!(runner.stop_reason, Some(StopReason::Saturated)));
 }
 
+#[test]
+fn test_unsound_union() {
+    let expr: RecExpr<Math> = "(+ (* x 1) y)".parse().unwrap();
+    let expr2 = "20".parse().unwrap();
+    let mut runner: Runner<Math, ConstantFold> = Runner::default()
+        .with_explanations_enabled()
+        .with_iter_limit(3)
+        .with_expr(&expr)
+        .run(&rules());
+    let lhs = runner.egraph.add_expr(&expr);
+    let rhs = runner.egraph.add_expr(&expr2);
+    runner.egraph.unsound_union_classes(lhs, rhs, "whatever");
+    let proof = runner.explain_equivalence(&expr, &expr2).get_flat_strings();
+    assert_eq!(
+        proof,
+        vec![
+            "(+ (* x 1) y)",
+            "(+ (Rewrite<= mul-one x) y)",
+            "(+ (Rewrite<= one-mul (* x 1)) y)",
+            "(Rewrite=> whatever 20)"
+        ]
+    );
+}
+
 #[cfg(feature = "lp")]
 #[test]
 fn math_lp_extract() {


### PR DESCRIPTION
Normally, unioning with explanations enabled involves using `union_instantiations`. This is a hassle because you need full `recexprs` or patterns that justify the union.

For e-class analysis demo purposes, it's easier to just let egg pick two "random" expressions in the e-class and use them to justify the union. That way you don't need to keep patterns around that justify your analysis. In the rare case that the reason that two eclasses are unioned does not depend on any specific term from either eclass, this method can be used.

One possible future of egg is that we return particular ids for particular terms in the egraph. Egg would return a particular id for your added expression, not the cannonical one for the eclass.  This gives you more power but makes it so that you have to be careful to canonicalize before you compare ids for e-class equality.