### PR TITLE
Add `search_with_limit`

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,4 +1,7 @@
 use crate::*;
+use std::result;
+
+type Result = result::Result<(), ()>;
 
 #[derive(Default)]
 struct Machine {
@@ -31,13 +34,21 @@ enum ENodeOrReg<L> {
 }
 
 #[inline(always)]
-fn for_each_matching_node<L, D>(eclass: &EClass<L, D>, node: &L, mut f: impl FnMut(&L))
+fn for_each_matching_node<L, D>(
+    eclass: &EClass<L, D>,
+    node: &L,
+    mut f: impl FnMut(&L) -> Result,
+) -> Result
 where
     L: Language,
 {
     #[allow(enum_intrinsics_non_enums)]
     if eclass.nodes.len() < 50 {
-        eclass.nodes.iter().filter(|n| node.matches(n)).for_each(f)
+        eclass
+            .nodes
+            .iter()
+            .filter(|n| node.matches(n))
+            .try_for_each(f)
     } else {
         debug_assert!(node.all(|id| id == Id::from(0)));
         debug_assert!(eclass.nodes.windows(2).all(|w| w[0] < w[1]));
@@ -50,7 +61,7 @@ where
                 break;
             }
         }
-        let matching = eclass.nodes[start..]
+        let mut matching = eclass.nodes[start..]
             .iter()
             .take_while(|&n| std::mem::discriminant(n) == discrim)
             .filter(|n| node.matches(n));
@@ -68,7 +79,7 @@ where
                 .collect::<HashSet<_>>(),
             eclass.nodes
         );
-        matching.for_each(&mut f);
+        matching.try_for_each(&mut f)
     }
 }
 
@@ -83,8 +94,9 @@ impl Machine {
         egraph: &EGraph<L, N>,
         instructions: &[Instruction<L>],
         subst: &Subst,
-        yield_fn: &mut impl FnMut(&Self, &Subst),
-    ) where
+        yield_fn: &mut impl FnMut(&Self, &Subst) -> Result,
+    ) -> Result
+    where
         L: Language,
         N: Analysis<L>,
     {
@@ -104,13 +116,13 @@ impl Machine {
                     for class in egraph.classes() {
                         self.reg.truncate(out.0 as usize);
                         self.reg.push(class.id);
-                        self.run(egraph, remaining_instructions, subst, yield_fn)
+                        self.run(egraph, remaining_instructions, subst, yield_fn)?
                     }
-                    return;
+                    return Ok(());
                 }
                 Instruction::Compare { i, j } => {
                     if egraph.find(self.reg(*i)) != egraph.find(self.reg(*j)) {
-                        return;
+                        return Ok(());
                     }
                 }
                 Instruction::Lookup { term, i } => {
@@ -121,7 +133,7 @@ impl Machine {
                                 let look = |i| self.lookup[usize::from(i)];
                                 match egraph.lookup(node.clone().map_children(look)) {
                                     Some(id) => self.lookup.push(id),
-                                    None => return,
+                                    None => return Ok(()),
                                 }
                             }
                             ENodeOrReg::Reg(r) => {
@@ -132,7 +144,7 @@ impl Machine {
 
                     let id = egraph.find(self.reg(*i));
                     if self.lookup.last().copied() != Some(id) {
-                        return;
+                        return Ok(());
                     }
                 }
             }
@@ -334,27 +346,51 @@ impl<L: Language> Program<L> {
     where
         A: Analysis<L>,
     {
-        let mut machine = Machine::default();
+        self.run_with_limit(egraph, eclass, usize::MAX)
+    }
 
+    pub fn run_with_limit<A>(
+        &self,
+        egraph: &EGraph<L, A>,
+        eclass: Id,
+        mut limit: usize,
+    ) -> Vec<Subst>
+    where
+        A: Analysis<L>,
+    {
         assert!(egraph.clean, "Tried to search a dirty e-graph!");
+
+        if limit == 0 {
+            return vec![];
+        }
+
+        let mut machine = Machine::default();
         assert_eq!(machine.reg.len(), 0);
         machine.reg.push(eclass);
 
         let mut matches = Vec::new();
-        machine.run(
-            egraph,
-            &self.instructions,
-            &self.subst,
-            &mut |machine, subst| {
-                let subst_vec = subst
-                    .vec
-                    .iter()
-                    // HACK we are reusing Ids here, this is bad
-                    .map(|(v, reg_id)| (*v, machine.reg(Reg(usize::from(*reg_id) as u32))))
-                    .collect();
-                matches.push(Subst { vec: subst_vec });
-            },
-        );
+        machine
+            .run(
+                egraph,
+                &self.instructions,
+                &self.subst,
+                &mut |machine, subst| {
+                    let subst_vec = subst
+                        .vec
+                        .iter()
+                        // HACK we are reusing Ids here, this is bad
+                        .map(|(v, reg_id)| (*v, machine.reg(Reg(usize::from(*reg_id) as u32))))
+                        .collect();
+                    matches.push(Subst { vec: subst_vec });
+                    limit -= 1;
+                    if limit != 0 {
+                        Ok(())
+                    } else {
+                        Err(())
+                    }
+                },
+            )
+            .unwrap_or_default();
 
         log::trace!("Ran program, found {:?}", matches);
         matches

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -101,8 +101,8 @@ impl<L: Language + FromOp> FromStr for MultiPattern<L> {
 }
 
 impl<L: Language, A: Analysis<L>> Searcher<L, A> for MultiPattern<L> {
-    fn search_eclass(&self, egraph: &EGraph<L, A>, eclass: Id) -> Option<SearchMatches<L>> {
-        let substs = self.program.run(egraph, eclass);
+    fn search_eclass_with_limit(&self, egraph: &EGraph<L, A>, eclass: Id, limit: usize) -> Option<SearchMatches<L>> {
+        let substs = self.program.run_with_limit(egraph, eclass, limit);
         if substs.is_empty() {
             None
         } else {

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -101,7 +101,12 @@ impl<L: Language + FromOp> FromStr for MultiPattern<L> {
 }
 
 impl<L: Language, A: Analysis<L>> Searcher<L, A> for MultiPattern<L> {
-    fn search_eclass_with_limit(&self, egraph: &EGraph<L, A>, eclass: Id, limit: usize) -> Option<SearchMatches<L>> {
+    fn search_eclass_with_limit(
+        &self,
+        egraph: &EGraph<L, A>,
+        eclass: Id,
+        limit: usize,
+    ) -> Option<SearchMatches<L>> {
         let substs = self.program.run_with_limit(egraph, eclass, limit);
         if substs.is_empty() {
             None

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -166,20 +166,14 @@ where
 {
     /// Search one eclass, returning None if no matches can be found.
     /// This should not return a SearchMatches with no substs.
-    ///
-    /// Implementation of [`Searcher`] should implement one of
-    /// [`search_eclass`] or [`search_eclass_with_limit`].
-    ///
-    /// [`search_eclass`]: Searcher::search_eclass
-    /// [`search_eclass_with_limit`]: Searcher::search_eclass_with_limit
     fn search_eclass(&self, egraph: &EGraph<L, N>, eclass: Id) -> Option<SearchMatches<L>> {
         self.search_eclass_with_limit(egraph, eclass, usize::MAX)
     }
 
     /// Similar to [`search_eclass`], but return at most `limit` many matches.
     ///
-    /// Implementation of [`Searcher`] should implement one of
-    /// [`search_eclass`] or [`search_eclass_with_limit`].
+    /// Implementation of [`Searcher`] should implement
+    /// [`search_eclass_with_limit`].
     ///
     /// [`search_eclass`]: Searcher::search_eclass
     /// [`search_eclass_with_limit`]: Searcher::search_eclass_with_limit
@@ -188,12 +182,7 @@ where
         egraph: &EGraph<L, N>,
         eclass: Id,
         limit: usize,
-    ) -> Option<SearchMatches<L>> {
-        self.search_eclass(egraph, eclass).map(|mut m| {
-            m.substs.truncate(limit);
-            m
-        })
-    }
+    ) -> Option<SearchMatches<L>>;
 
     /// Search the whole [`EGraph`], returning a list of all the
     /// [`SearchMatches`] where something was found.

--- a/src/run.rs
+++ b/src/run.rs
@@ -860,9 +860,9 @@ where
             return vec![];
         }
 
-        let matches = rewrite.search(egraph);
-        let total_len: usize = matches.iter().map(|m| m.substs.len()).sum();
         let threshold = stats.match_limit << stats.times_banned;
+        let matches = rewrite.search_with_limit(egraph, threshold + 1);
+        let total_len: usize = matches.iter().map(|m| m.substs.len()).sum();
         if total_len > threshold {
             let ban_length = stats.ban_length << stats.times_banned;
             stats.times_banned += 1;


### PR DESCRIPTION
Currently, the `BackoffScheduler` will search each pattern, and if the match size is larger than the threshold, all the matches will be threw away and the rule will be banned. However, rules like AC will take an intractable amount of time and find ridiculously many matches, even when the threshold is small.

This PR tries to add an interface for `search_with_limit` and `search_eclass_with_limit`, while being compatible with the existing interface. With this PR, the e-matching machine will stop searching as soon as the number of matches hits the limit.