### PR TITLE
Fix the performance issue with math test suite

### DIFF
--- a/tests/math.rs
+++ b/tests/math.rs
@@ -82,8 +82,8 @@ impl Analysis<Math> for ConstantFold {
     }
 
     fn modify(egraph: &mut EGraph, id: Id) {
-        let class = &egraph[id];
-        if let Some((c, pat)) = class.data {
+        let data = egraph[id].data.clone();
+        if let Some((c, pat)) = data {
             if egraph.are_explanations_enabled() {
                 egraph.union_instantiations(
                     &pat,

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -82,7 +82,7 @@ impl Analysis<Math> for ConstantFold {
     }
 
     fn modify(egraph: &mut EGraph, id: Id) {
-        let class = egraph[id].clone();
+        let class = &egraph[id];
         if let Some((c, pat)) = class.data {
             if egraph.are_explanations_enabled() {
                 egraph.union_instantiations(


### PR DESCRIPTION
Under an application-intensive scheduler like SimpleScheduler, math could take 100% of its time doing the cloning in its analysis. See the screenshot below:
<img width="1438" alt="Screen Shot 2022-09-26 at 2 28 18 PM" src="https://user-images.githubusercontent.com/13150100/192384556-798f2cdc-1a9d-4342-bdcb-f9f06bf49f8a.png">
