### PR TITLE
Fix performance bug in displaying let-bound version of proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,27 @@
 ## [0.9.3] - 2022-02-06
 
 ### Added
-- ([#215] https://github.com/egraphs-good/egg/pull/215) Added a better intersection algorithms on two egraphs based on "Join Algorithms for the Theory of Uninterpreted Functions". The old intersection algorithm was not complete on the terms in both egraphs, but the new one is. Unfortunately, the new algorithm is quadratic.
+- [#215](https://github.com/egraphs-good/egg/pull/215) Added a better intersection algorithms on two egraphs based on "Join Algorithms for the Theory of Uninterpreted Functions". The old intersection algorithm was not complete on the terms in both egraphs, but the new one is. Unfortunately, the new algorithm is quadratic.
 
 ### Changed
-- ([#230] https://github.com/egraphs-good/egg/pull/230) Fixed a performance bug in `get_string_with_let` that caused printing let-bound proofs to be extremely inefficient.
+- [#230](https://github.com/egraphs-good/egg/pull/230) Fixed a performance bug in `get_string_with_let` that caused printing let-bound proofs to be extremely inefficient.
 
 
 ## [0.9.2] - 2022-12-15
 
 ### Added
 
-- ([#210] https://github.com/egraphs-good/egg/pull/210) Fix crashes in proof generation due to proof size calculations overflowing.
+- [#210](https://github.com/egraphs-good/egg/pull/210) Fix crashes in proof generation due to proof size calculations overflowing.
 
 ## [0.9.1] - 2022-09-22
 
 ### Added
 
-- ([#186] https://github.com/egraphs-good/egg/pull/186) Added proof minimization (enabled by default), a greedy algorithm to find smaller proofs
+- [#186](https://github.com/egraphs-good/egg/pull/186) Added proof minimization (enabled by default), a greedy algorithm to find smaller proofs
   - with and `without_explanation_length_optimization` for turning this on and off
   - `copy_without_unions` for copying an egraph but without any equality information
   - `id_to_expr` for getting an expression corresponding to a particular enode's id
-- ([#197] https://github.com/egraphs-good/egg/pull/197) Added `search_with_limit`, so that matching also stops when it hits scheduling limits.
+- [#197](https://github.com/egraphs-good/egg/pull/197) Added `search_with_limit`, so that matching also stops when it hits scheduling limits.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+## [0.9.3] - 2022-02-06
+
+### Added
 - ([#215] https://github.com/egraphs-good/egg/pull/215) Added a better intersection algorithms on two egraphs based on "Join Algorithms for the Theory of Uninterpreted Functions". The old intersection algorithm was not complete on the terms in both egraphs, but the new one is. Unfortunately, the new algorithm is quadratic.
+
+### Changed
+- ([#230] https://github.com/egraphs-good/egg/pull/230) Fixed a performance bug in `get_string_with_let` that caused printing let-bound proofs to be extremely inefficient.
 
 
 ## [0.9.2] - 2022-12-15
@@ -225,8 +231,9 @@ But hopefully things will be a little more stable from here on out
 since the API is a lot nicer.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/egraphs-good/egg/compare/v0.9.2...HEAD
-[0.9.2]: https://github.com/egraphs-good/egg/compare/v0.9.0...v0.9.2
+[Unreleased]: https://github.com/egraphs-good/egg/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/egraphs-good/egg/compare/v0.9.2...v0.9.3
+[0.9.2]: https://github.com/egraphs-good/egg/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/egraphs-good/egg/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/egraphs-good/egg/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/egraphs-good/egg/compare/v0.8.0...v0.8.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egg"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Max Willsey <me@mwillsey.com>"]
 edition = "2018"
 description = "An implementation of egraphs"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check out the [web demo](https://egraphs-good.github.io/egg-web-demo) for some q
 Add `egg` to your `Cargo.toml` like this:
 ```toml
 [dependencies]
-egg = "0.9.2"
+egg = "0.9.3"
 ```
 
 Make sure to compile with `--release` if you are measuring performance!

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -277,14 +277,11 @@ impl<L: Language + Display + FromOp> Explanation<L> {
     }
 
     fn get_sexp_with_let(&self) -> Sexp {
-        eprintln!("get_sexp_with_let");
         let mut shared: HashSet<*const TreeTerm<L>> = Default::default();
         let mut to_let_bind = vec![];
-        eprintln!("before find_to_let_bind");
         for term in &self.explanation_trees {
             self.find_to_let_bind(term.clone(), &mut shared, &mut to_let_bind);
         }
-        eprintln!("after find_to_let_bind");
 
         let mut bindings: HashMap<*const TreeTerm<L>, Sexp> = Default::default();
         let mut generated_bindings: Vec<(Sexp, Sexp)> = Default::default();
@@ -296,7 +293,6 @@ impl<L: Language + Display + FromOp> Explanation<L> {
                 bindings.insert(&*to_bind as *const TreeTerm<L>, name);
             }
         }
-        eprintln!("after generated");
 
         let mut items = vec![Sexp::String("Explanation".to_string())];
         for e in self.explanation_trees.iter() {
@@ -307,16 +303,12 @@ impl<L: Language + Display + FromOp> Explanation<L> {
             }
         }
 
-        eprintln!("after get_sexp_with_bindings");
-
         let mut result = Sexp::List(items);
 
         for (name, expr) in generated_bindings.into_iter().rev() {
             let let_expr = Sexp::List(vec![name, expr]);
             result = Sexp::List(vec![Sexp::String("let".to_string()), let_expr, result]);
         }
-
-        eprintln!("returning");
 
         result
     }

--- a/src/tutorials/_02_getting_started.rs
+++ b/src/tutorials/_02_getting_started.rs
@@ -36,7 +36,7 @@ First,
 Now we can add `egg` as a project dependency by adding a line to `Cargo.toml`:
 ```toml
 [dependencies]
-egg = "0.9.2"
+egg = "0.9.3"
 ```
 
 All of the code samples below work, but you'll have to `use` the relevant types.


### PR DESCRIPTION
Previously, `get_string_with_let` had a bad performance bug when finding common expressions to let-bind. This PR fixes that problem.