### PR TITLE
Optimize path compression of union-find

### DIFF
--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -33,13 +33,11 @@ impl UnionFind {
         current
     }
 
-    pub fn find_mut(&mut self, mut current: Id) -> Id {
-        while current != self.parent(current) {
-            let grandparent = self.parent(self.parent(current));
-            *self.parent_mut(current) = grandparent;
-            current = grandparent;
+    pub fn find_mut(&mut self, current: Id) -> Id {
+        if current != self.parent(current) {
+            *self.parent_mut(current) = self.find_mut(self.parent(current));
         }
-        current
+        self.parent(current)
     }
 
     /// Given two leader ids, unions the two eclasses making root1 the leader.


### PR DESCRIPTION
Before:

```console
$ hyperfine --warmup=3 'cargo test --test lambda --release -- --nocapture --test --test-threads=1'
Benchmark 1: cargo test --test lambda --release -- --nocapture --test --test-threads=1
  Time (mean ± σ):     870.4 ms ±  22.7 ms    [User: 845.0 ms, System: 23.2 ms]
  Range (min … max):   841.0 ms … 912.3 ms    10 runs
```

After:

```console
$ hyperfine --warmup=3 'cargo test --test lambda --release -- --nocapture --test --test-threads=1'
Benchmark 1: cargo test --test lambda --release -- --nocapture --test --test-threads=1
  Time (mean ± σ):     848.1 ms ±  16.2 ms    [User: 823.6 ms, System: 22.3 ms]
  Range (min … max):   829.7 ms … 874.2 ms    10 runs
```

If we can eliminate the boundary check of index operations, the performance could be a bit faster.