### PR TITLE
avoid panicked at 'attempt to add with overflow'

### DIFF
--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -48,7 +48,7 @@ fn eval(egraph: &EGraph, enode: &Lambda) -> Option<(Lambda, PatternAst<Lambda>)>
         Lambda::Num(n) => Some((enode.clone(), format!("{}", n).parse().unwrap())),
         Lambda::Bool(b) => Some((enode.clone(), format!("{}", b).parse().unwrap())),
         Lambda::Add([a, b]) => Some((
-            Lambda::Num(x(a)?.num()? + x(b)?.num()?),
+            Lambda::Num(x(a)?.num()?.checked_add(x(b)?.num()?)?),
             format!("(+ {} {})", x(a)?, x(b)?).parse().unwrap(),
         )),
         Lambda::Eq([a, b]) => Some((


### PR DESCRIPTION
Fix integer overflow issue in addition operation. It may cause panicked at 'attempt to add with overflow'
A possible example is: `(+ 2147483647 1)`
*When I tried to implement a custom language based on tests/lambda.rs, I found that this issue can easily arise.*