### PR TITLE
impl From for converting a &RecExpr<L> to a Pattern<L>.

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -214,6 +214,12 @@ impl<'a, L: Language> From<&'a [L]> for Pattern<L> {
     }
 }
 
+impl<L: Language> From<&RecExpr<L>> for Pattern<L> {
+    fn from(expr: &RecExpr<L>) -> Self {
+        Self::from(expr.as_ref())
+    }
+}
+
 impl<L: Language> From<PatternAst<L>> for Pattern<L> {
     fn from(ast: PatternAst<L>) -> Self {
         Self::new(ast)


### PR DESCRIPTION
A RecExpr is like a Pattern with no variables in it, so allow converting it to the more general type.