### PR TITLE
allow per-language discriminants

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 #[cfg(feature = "serde-1")]
-use ::serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use log::*;
 
@@ -76,7 +76,7 @@ pub struct EGraph<L: Language, N: Analysis<L>> {
     pub(crate) classes: HashMap<Id, EClass<L, N::Data>>,
     #[cfg_attr(feature = "serde-1", serde(skip))]
     #[cfg_attr(feature = "serde-1", serde(default = "default_classes_by_op"))]
-    pub(crate) classes_by_op: HashMap<std::mem::Discriminant<L>, HashSet<Id>>,
+    pub(crate) classes_by_op: HashMap<L::Discriminant, HashSet<Id>>,
     /// Whether or not reading operation are allowed on this e-graph.
     /// Mutating operations will set this to `false`, and
     /// [`EGraph::rebuild`] will set it to true.
@@ -977,9 +977,8 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             trimmed += old_len - class.nodes.len();
 
             let mut add = |n: &L| {
-                #[allow(enum_intrinsics_non_enums)]
                 classes_by_op
-                    .entry(std::mem::discriminant(n))
+                    .entry(n.discriminant())
                     .or_default()
                     .insert(class.id)
             };

--- a/src/language.rs
+++ b/src/language.rs
@@ -29,8 +29,12 @@ use thiserror::Error;
 /// See [`SymbolLang`] for quick-and-dirty use cases.
 #[allow(clippy::len_without_is_empty)]
 pub trait Language: Debug + Clone + Eq + Ord + Hash {
+    /// Type representing the cases of this language.
+    ///
+    /// Used for short-circuiting the search for equivalent nodes.
     type Discriminant: Debug + Clone + Eq + Hash;
 
+    /// Return the `Discriminant` of this node.
     #[allow(enum_intrinsics_non_enums)]
     fn discriminant(&self) -> Self::Discriminant;
 
@@ -834,7 +838,7 @@ impl Language for SymbolLang {
     type Discriminant = Symbol;
 
     fn discriminant(&self) -> Self::Discriminant {
-        self.op.clone()
+        self.op
     }
 
     fn matches(&self, other: &Self) -> bool {

--- a/src/language.rs
+++ b/src/language.rs
@@ -29,6 +29,11 @@ use thiserror::Error;
 /// See [`SymbolLang`] for quick-and-dirty use cases.
 #[allow(clippy::len_without_is_empty)]
 pub trait Language: Debug + Clone + Eq + Ord + Hash {
+    type Discriminant: Debug + Clone + Eq + Hash;
+
+    #[allow(enum_intrinsics_non_enums)]
+    fn discriminant(&self) -> Self::Discriminant;
+
     /// Returns true if this enode matches another enode.
     /// This should only consider the operator, not the children `Id`s.
     fn matches(&self, other: &Self) -> bool;
@@ -826,6 +831,12 @@ impl SymbolLang {
 }
 
 impl Language for SymbolLang {
+    type Discriminant = Symbol;
+
+    fn discriminant(&self) -> Self::Discriminant {
+        self.op.clone()
+    }
+
     fn matches(&self, other: &Self) -> bool {
         self.op == other.op && self.len() == other.len()
     }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -42,7 +42,6 @@ fn for_each_matching_node<L, D>(
 where
     L: Language,
 {
-    #[allow(enum_intrinsics_non_enums)]
     if eclass.nodes.len() < 50 {
         eclass
             .nodes
@@ -53,9 +52,9 @@ where
         debug_assert!(node.all(|id| id == Id::from(0)));
         debug_assert!(eclass.nodes.windows(2).all(|w| w[0] < w[1]));
         let mut start = eclass.nodes.binary_search(node).unwrap_or_else(|i| i);
-        let discrim = std::mem::discriminant(node);
+        let discrim = node.discriminant();
         while start > 0 {
-            if std::mem::discriminant(&eclass.nodes[start - 1]) == discrim {
+            if eclass.nodes[start - 1].discriminant() == discrim {
                 start -= 1;
             } else {
                 break;
@@ -63,7 +62,7 @@ where
         }
         let mut matching = eclass.nodes[start..]
             .iter()
-            .take_while(|&n| std::mem::discriminant(n) == discrim)
+            .take_while(|&n| n.discriminant() == discrim)
             .filter(|n| node.matches(n));
         debug_assert_eq!(
             matching.clone().count(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,6 +11,8 @@ based on either the data of variants or the provided strings.
 The final variant **must have a trailing comma**; this is due to limitations in
 macro parsing.
 
+The language discriminant will use the cases of the enum (the enum discriminant).
+
 See [`LanguageChildren`] for acceptable types of children `Id`s.
 
 Note that you can always implement [`Language`] yourself by just not using this

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -79,6 +79,13 @@ macro_rules! __define_language {
         $vis enum $name $decl
 
         impl $crate::Language for $name {
+            type Discriminant = std::mem::Discriminant<Self>;
+
+            #[inline(always)]
+            fn discriminant(&self) -> Self::Discriminant {
+                std::mem::discriminant(self)
+            }
+
             #[inline(always)]
             fn matches(&self, other: &Self) -> bool {
                 ::std::mem::discriminant(self) == ::std::mem::discriminant(other) &&


### PR DESCRIPTION
For languages like `SymbolLang` that don't have an outer-most enum this allows defining a discriminant and reducing the set of nodes considered for matching. This allows each `Language` to determine the type to use for the discriminant and how to compute it.

For instance:

1. This may be a `std::mem::Discriminant<Self>` if the type is an enum
2. This may be a `u64` if it is easy to hash the "operation"
3. This may be `Symbol` for something like SymbolLang (or a discriminant of the operation, in the case of something like SymbolLang but using an enum for the symbol)
4. This may be something a bit richer for cases like `ENodeOrVar`.

This also allows languages to trade-off how rich the discriminant is with how efficient it is to compute / compare.