### PR TITLE
Clean up proof code using saturating numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,26 +11,27 @@ repository = "https://github.com/egraphs-good/egg"
 version = "0.9.5"
 
 [dependencies]
-env_logger = {version = "0.9.0", default-features = false}
+env_logger = { version = "0.9.0", default-features = false }
 fxhash = "0.2.1"
 hashbrown = "0.12.1"
 indexmap = "1.8.1"
 instant = "0.1.12"
 log = "0.4.17"
-smallvec = {version = "1.8.0", features = ["union", "const_generics"]}
-symbol_table = {version = "0.2.0", features = ["global"]}
+smallvec = { version = "1.8.0", features = ["union", "const_generics"] }
+symbol_table = { version = "0.2.0", features = ["global"] }
 symbolic_expressions = "5.0.3"
 thiserror = "1.0.31"
 
 # for the lp feature
-coin_cbc = {version = "0.1.6", optional = true}
+coin_cbc = { version = "0.1.6", optional = true }
 
 # for the serde-1 feature
-serde = {version = "1.0.137", features = ["derive"], optional = true}
-vectorize = {version = "0.2.0", optional = true}
+serde = { version = "1.0.137", features = ["derive"], optional = true }
+vectorize = { version = "0.2.0", optional = true }
 
 # for the reports feature
-serde_json = {version = "1.0.81", optional = true}
+serde_json = { version = "1.0.81", optional = true }
+saturating = "0.1.0"
 
 [dev-dependencies]
 ordered-float = "3.0.0"

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -65,6 +65,7 @@ pub struct Explain<L: Language> {
     // the explanation.
     // Invariant: The distance is always <= the unoptimized distance
     // That is, less than or equal to the result of `distance_between`
+    #[cfg_attr(feature = "serde-1", serde(skip))]
     shortest_explanation_memo: HashMap<(Id, Id), (ProofCost, Id)>,
 }
 

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -241,7 +241,7 @@ impl<L: Language + Display + FromOp> Explanation<L> {
         let mut seen_adjacent = Default::default();
         let mut sum: ProofCost = Saturating(0);
         for e in self.explanation_trees.iter() {
-            sum = sum + self.tree_size(&mut seen, &mut seen_adjacent, e);
+            sum += self.tree_size(&mut seen, &mut seen_adjacent, e);
         }
         sum
     }
@@ -273,7 +273,7 @@ impl<L: Language + Display + FromOp> Explanation<L> {
 
         for child_proof in &current.child_proofs {
             for child in child_proof {
-                my_size = self.tree_size(seen, seen_adjacent, child);
+                my_size += self.tree_size(seen, seen_adjacent, child);
             }
         }
         my_size
@@ -1492,7 +1492,6 @@ impl<L: Language> Explain<L> {
     ) {
         self.shortest_explanation_memo
             .insert((right, right), (Saturating(0), right));
-        let mut last_cost = Saturating(0);
         for connection in left_connections.iter().rev() {
             let next = connection.next;
             let current = connection.current;
@@ -1502,7 +1501,6 @@ impl<L: Language> Explain<L> {
                 .unwrap()
                 .0;
             let dist = self.connection_distance(connection, distance_memo);
-            last_cost = dist + next_cost;
             self.replace_distance(current, next, right, next_cost + dist);
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,6 +5,8 @@ These are not considered part of the public api.
 
 use std::{fmt::Display, fs::File, io::Write, path::PathBuf};
 
+use saturating::Saturating;
+
 use crate::*;
 
 pub fn env_var<T>(s: &str) -> Option<T>
@@ -102,14 +104,14 @@ pub fn test_runner<L, A>(
                 let flattened = explained.make_flat_explanation().clone();
                 let vanilla_len = flattened.len();
                 explained.check_proof(rules);
-                assert!(explained.get_tree_size() > 0);
+                assert!(explained.get_tree_size() > Saturating(0));
 
                 runner = runner.with_explanation_length_optimization();
                 let mut explained_short = runner.explain_matches(&start, &goal.ast, &subst);
                 explained_short.get_string_with_let();
                 let short_len = explained_short.get_flat_strings().len();
                 assert!(short_len <= vanilla_len);
-                assert!(explained_short.get_tree_size() > 0);
+                assert!(explained_short.get_tree_size() > Saturating(0));
                 explained_short.check_proof(rules);
             }
         }


### PR DESCRIPTION
This PR cleans up explanations to use saturating numbers to help prevent bugs. It also fixes a bug, deleting an incorrect assertion which is only true when there is no overflow.