### PR TITLE
allow converting `RecExpr` to `Vec<L>`

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -398,6 +398,12 @@ impl<L> From<Vec<L>> for RecExpr<L> {
     }
 }
 
+impl<L> From<RecExpr<L>> for Vec<L> {
+    fn from(val: RecExpr<L>) -> Self {
+        val.nodes
+    }
+}
+
 impl<L: Language> RecExpr<L> {
     /// Adds a given enode to this `RecExpr`.
     /// The enode's children `Id`s must refer to elements already in this list.


### PR DESCRIPTION
This allows a variety of manipulation to be done without needing to copy the nodes. For instance, applying some logic to each node to produce a new `RecExpr` can move out of the old expressions.