### PR TITLE
Optimised the `classes` field of `EGraph` to avoid extra hashing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ mod subst;
 mod unionfind;
 mod util;
 
+const U31_MAX: u32 = (1 << (u32::BITS - 1)) - 1;
+
 /// A key to identify [`EClass`]es within an
 /// [`EGraph`].
 #[derive(Clone, Copy, Default, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -61,8 +63,13 @@ mod util;
 #[cfg_attr(feature = "serde-1", serde(transparent))]
 pub struct Id(u32);
 
+impl Id {
+    const MAX: Id = Id(U31_MAX);
+}
+
 impl From<usize> for Id {
     fn from(n: usize) -> Id {
+        assert!(n <= U31_MAX as usize);
         Id(n as u32)
     }
 }
@@ -82,6 +89,29 @@ impl std::fmt::Debug for Id {
 impl std::fmt::Display for Id {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// Index into the classes field of an [`EGraph`]
+#[derive(Hash, Clone, Copy, Eq, PartialEq)]
+struct ClassId(u32);
+
+impl std::fmt::Debug for ClassId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<usize> for ClassId {
+    fn from(n: usize) -> ClassId {
+        assert!(n <= U31_MAX as usize);
+        ClassId(n as u32)
+    }
+}
+
+impl From<ClassId> for usize {
+    fn from(id: ClassId) -> usize {
+        id.0 as usize
     }
 }
 

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -9,6 +9,8 @@ enum UnionFindElt {
 
 /// Compact version of [`UnionFindElt`]
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-1", serde(transparent))]
 struct RawUnionFindElt(u32);
 
 const RAW_ELT_DATA_MASK: u32 = U31_MAX;

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,16 +1,70 @@
-use crate::Id;
-use std::fmt::Debug;
+use crate::{ClassId, Id, U31_MAX};
+use std::fmt::{Debug, Formatter};
+
+#[derive(Debug, Copy, Clone)]
+enum UnionFindElt {
+    Parent(Id),
+    Root(ClassId),
+}
+
+/// Compact version of [`UnionFindElt`]
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct RawUnionFindElt(u32);
+
+const RAW_ELT_DATA_MASK: u32 = U31_MAX;
+const RAW_ELT_FLAG_MASK: u32 = U31_MAX + 1;
+
+impl From<UnionFindElt> for RawUnionFindElt {
+    fn from(elt: UnionFindElt) -> Self {
+        match elt {
+            UnionFindElt::Parent(Id(x)) => {
+                debug_assert_eq!(x, x & !RAW_ELT_FLAG_MASK);
+                // all Id's must be 31 bits
+                RawUnionFindElt(x)
+            }
+            UnionFindElt::Root(ClassId(x)) => RawUnionFindElt(x | RAW_ELT_FLAG_MASK),
+        }
+    }
+}
+
+impl From<RawUnionFindElt> for UnionFindElt {
+    fn from(RawUnionFindElt(elt): RawUnionFindElt) -> Self {
+        let data = elt & RAW_ELT_DATA_MASK;
+        if elt & RAW_ELT_FLAG_MASK == 0 {
+            UnionFindElt::Parent(Id(data))
+        } else {
+            UnionFindElt::Root(ClassId(data))
+        }
+    }
+}
+
+impl Debug for RawUnionFindElt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        UnionFindElt::from(*self).fmt(f)
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnionFind {
-    parents: Vec<Id>,
+    parents: Vec<RawUnionFindElt>,
 }
 
 impl UnionFind {
     pub fn make_set(&mut self) -> Id {
+        self.make_set_with_id(0.into())
+    }
+
+    pub(super) fn make_set_with_id(&mut self, class_id: ClassId) -> Id {
         let id = Id::from(self.parents.len());
-        self.parents.push(id);
+        self.parents.push(UnionFindElt::Root(class_id).into());
+        id
+    }
+
+    /// Creates a fresh non-canonical id with the parent `parent`
+    pub fn make_child_set(&mut self, parent: Id) -> Id {
+        let id = Id::from(self.parents.len());
+        self.parents.push(UnionFindElt::Parent(parent).into());
         id
     }
 
@@ -18,33 +72,55 @@ impl UnionFind {
         self.parents.len()
     }
 
-    fn parent(&self, query: Id) -> Id {
-        self.parents[usize::from(query)]
+    fn parent(&self, query: Id) -> UnionFindElt {
+        self.parents[usize::from(query)].into()
     }
 
-    fn parent_mut(&mut self, query: Id) -> &mut Id {
-        &mut self.parents[usize::from(query)]
+    fn set_parent(&mut self, query: Id, parent: Id) {
+        self.parents[usize::from(query)] = UnionFindElt::Parent(parent).into()
     }
 
-    pub fn find(&self, mut current: Id) -> Id {
-        while current != self.parent(current) {
-            current = self.parent(current)
+    pub(super) fn reset_root(&mut self, query: Id, class_id: ClassId) {
+        debug_assert!(matches!(self.parent(query), UnionFindElt::Root(_)));
+        self.parents[usize::from(query)] = UnionFindElt::Root(class_id).into()
+    }
+
+    pub(super) fn find_full(&self, mut current: Id) -> (Id, ClassId) {
+        loop {
+            match self.parent(current) {
+                UnionFindElt::Parent(parent) => current = parent,
+                UnionFindElt::Root(cid) => return (current, cid),
+            }
         }
-        current
     }
 
-    pub fn find_mut(&mut self, mut current: Id) -> Id {
-        while current != self.parent(current) {
-            let grandparent = self.parent(self.parent(current));
-            *self.parent_mut(current) = grandparent;
-            current = grandparent;
+    pub fn find(&self, current: Id) -> Id {
+        self.find_full(current).0
+    }
+
+    pub(super) fn find_mut_full(&mut self, mut current: Id) -> (Id, ClassId) {
+        let canon = self.find(current);
+        loop {
+            match self.parent(current) {
+                UnionFindElt::Parent(parent) => {
+                    self.set_parent(current, canon);
+                    current = parent;
+                }
+                UnionFindElt::Root(cid) => {
+                    debug_assert!(current == canon);
+                    return (current, cid);
+                }
+            }
         }
-        current
+    }
+
+    pub fn find_mut(&mut self, current: Id) -> Id {
+        self.find_mut_full(current).0
     }
 
     /// Given two leader ids, unions the two eclasses making root1 the leader.
     pub fn union(&mut self, root1: Id, root2: Id) -> Id {
-        *self.parent_mut(root2) = root1;
+        self.set_parent(root2, root1);
         root1
     }
 }
@@ -53,22 +129,21 @@ impl UnionFind {
 mod tests {
     use super::*;
 
-    fn ids(us: impl IntoIterator<Item = usize>) -> Vec<Id> {
-        us.into_iter().map(|u| u.into()).collect()
-    }
-
     #[test]
     fn union_find() {
         let n = 10;
         let id = Id::from;
 
         let mut uf = UnionFind::default();
-        for _ in 0..n {
-            uf.make_set();
+        for i in 0..n {
+            uf.make_set_with_id(i.into());
         }
 
+        let root = |x: usize| RawUnionFindElt::from(UnionFindElt::Root(x.into()));
+        let parent = |x: usize| RawUnionFindElt::from(UnionFindElt::Parent(x.into()));
+
         // test the initial condition of everyone in their own set
-        assert_eq!(uf.parents, ids(0..n));
+        assert_eq!(uf.parents, (0..n).into_iter().map(root).collect::<Vec<_>>());
 
         // build up one set
         uf.union(id(0), id(1));
@@ -86,7 +161,18 @@ mod tests {
         }
 
         // indexes:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9
-        let expected = vec![0, 0, 0, 0, 4, 5, 6, 6, 6, 6];
-        assert_eq!(uf.parents, ids(expected));
+        let expected = vec![
+            root(0),
+            parent(0),
+            parent(0),
+            parent(0),
+            root(4),
+            root(5),
+            root(6),
+            parent(6),
+            parent(6),
+            parent(6),
+        ];
+        assert_eq!(uf.parents, expected);
     }
 }


### PR DESCRIPTION
I noticed that the `classes` field of an `EGraph` is currently represented using a `HashMap<Id, EClass>` (or possibly an `IndexMap`). Since the set of possible `Id`s form a continuous range and the `union_find` field already contains an element for each `Id`, I thought I could try to use it like an "index" for an `IndexMap`, this works especially well since it currently maps non-canonical `Id`s to there parent, and we would need it to map canonical `Id`s to the index into the class list, so each element of the `union_find` would only need to have an index into another list and a tag of whether or not it's canonical. I decided to use one bit of a u32 as the tag so that the `union_find` would stay the same size.

Hopefully, this will improve performance (do you have a setup for reliably benchmarking two commits and comparing them?)

The main downside to this change is that `EGraph`s can now only support 2^31 `Id`s instead of 2^32 and that we now rely more on the `EClass`s `id` field so if a user changes it (this is possible since it is public) it would likely break the `EGraph` (if it didn't already).