### PR TITLE
An approach to a string-free API

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -626,7 +626,10 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Like [`add_uncanonical`](EGraph::add_uncanonical), when explanations are enabled calling
     /// Calling [`id_to_expr`](EGraph::id_to_expr) on this `Id` return an corrispond to the
     /// instantiation of the pattern
-    fn add_instantiation_noncanonical(&mut self, pat: &PatternAst<L>, subst: &Subst) -> Id {
+    fn add_instantiation_noncanonical<V>(&mut self, pat: &PatternAst<L, V>, subst: &Subst<V>) -> Id
+    where
+        V: std::fmt::Debug + Clone + std::hash::Hash + PartialOrd + Ord + Copy + std::fmt::Display,
+    {
         let nodes = pat.as_ref();
         let mut new_ids = Vec::with_capacity(nodes.len());
         let mut new_node_q = Vec::with_capacity(nodes.len());
@@ -850,13 +853,16 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     ///
     /// Returns the id of the new eclass, along with
     /// a `bool` indicating whether a union occured.
-    pub fn union_instantiations(
+    pub fn union_instantiations<V>(
         &mut self,
-        from_pat: &PatternAst<L>,
-        to_pat: &PatternAst<L>,
-        subst: &Subst,
+        from_pat: &PatternAst<L, V>,
+        to_pat: &PatternAst<L, V>,
+        subst: &Subst<V>,
         rule_name: impl Into<Symbol>,
-    ) -> (Id, bool) {
+    ) -> (Id, bool)
+    where
+        V: std::fmt::Debug + Clone + std::hash::Hash + PartialOrd + Ord + Copy + std::fmt::Display,
+    {
         let id1 = self.add_instantiation_noncanonical(from_pat, subst);
         let size_before = self.unionfind.size();
         let id2 = self.add_instantiation_noncanonical(to_pat, subst);
@@ -1204,7 +1210,10 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         n_unions
     }
 
-    pub(crate) fn check_each_explain(&self, rules: &[&Rewrite<L, N>]) -> bool {
+    pub(crate) fn check_each_explain<V>(&self, rules: &[&Rewrite<L, N, V>]) -> bool
+    where
+        V: std::fmt::Debug + Clone + std::hash::Hash + PartialOrd + Ord + Copy + std::fmt::Display,
+    {
         if let Some(explain) = &self.explain {
             explain.check_each_explain(rules)
         } else {

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -22,9 +22,9 @@ use crate::*;
 ///
 /// Multipatterns currently do not support the explanations feature.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct MultiPattern<L> {
+pub struct MultiPattern<L, V = Var> {
     asts: Vec<(Var, PatternAst<L>)>,
-    program: machine::Program<L>,
+    program: machine::Program<L, V>,
 }
 
 impl<L: Language> MultiPattern<L> {
@@ -274,11 +274,11 @@ mod tests {
         let z1 = egraph.add_string("(tag z ctx2)");
         egraph.union(x1, y1);
         egraph.union(y2, z2);
-        let rules = vec![multi_rewrite!("context-transfer"; 
-                     "?x = (tag ?a ?ctx1) = (tag ?b ?ctx1), 
-                      ?t = (lte ?ctx1 ?ctx2), 
-                      ?a1 = (tag ?a ?ctx2), 
-                      ?b1 = (tag ?b ?ctx2)" 
+        let rules = vec![multi_rewrite!("context-transfer";
+                     "?x = (tag ?a ?ctx1) = (tag ?b ?ctx1),
+                      ?t = (lte ?ctx1 ?ctx2),
+                      ?a1 = (tag ?a ?ctx2),
+                      ?b1 = (tag ?b ?ctx2)"
                       =>
                       "?a1 = ?b1")];
         let runner = Runner::default().with_egraph(egraph).run(&rules);

--- a/tests/no_strings.rs
+++ b/tests/no_strings.rs
@@ -1,0 +1,52 @@
+use egg::*;
+
+define_language! {
+    enum NoStrings {
+        Num(i32),
+        "🦑" = Squid([Id; 2]),
+        "🐝" = Bee(Id),
+        Symbol(Symbol),
+    }
+}
+
+fn make_rules() -> Vec<Rewrite<NoStrings, (), i32>> {
+    let searcher: Pattern<NoStrings, _> = Pattern::new(RecExpr::from(vec![
+        ENodeOrVar::Var(12 as i32),
+        ENodeOrVar::Var(13 as i32),
+        ENodeOrVar::ENode(NoStrings::Squid([0.into(), 1.into()])),
+    ]));
+    let applier: Pattern<NoStrings, _> = Pattern::new(RecExpr::from(vec![
+        ENodeOrVar::Var(13 as i32),
+        ENodeOrVar::ENode(NoStrings::Bee(0.into())),
+    ]));
+    vec![crate::Rewrite::new("squid to bee".to_string(), searcher, applier).unwrap()]
+}
+
+#[test]
+fn simple_tests() {
+    assert_eq!(
+        simplify(RecExpr::from(vec![
+            NoStrings::Num(77 as i32),
+            NoStrings::Num(88 as i32),
+            NoStrings::Squid([0.into(), 1.into()]),
+        ])),
+        RecExpr::from(vec![NoStrings::Num(88 as i32), NoStrings::Bee(0.into()),])
+    );
+}
+
+/// simplify using egg, and pretty print it back out
+fn simplify(expr: RecExpr<NoStrings>) -> RecExpr<NoStrings> {
+    // simplify the expression using a Runner, which creates an e-graph with
+    // the given expression and runs the given rules over it
+    let runner: Runner<NoStrings, _, (), i32> =
+        Runner::default().with_expr(&expr).run(&make_rules());
+
+    // the Runner knows which e-class the expression given with `with_expr` is in
+    let root = runner.roots[0];
+
+    // use an Extractor to pick the best element of the root eclass
+    let extractor = Extractor::new(&runner.egraph, AstSize);
+    let (best_cost, best) = extractor.find_best(root);
+    println!("Simplified {} to {} with cost {}", expr, best, best_cost);
+    best
+}


### PR DESCRIPTION
This change is to support a string-free API to create rewrites as discussed in https://github.com/egraphs-good/egg/issues/219

I do need this functionality to use egg with my own IR, so it would be great if it landed. 

However, if supporting a string-free API is better done using some other approach, I'm happy to do that instead. Just doing this to illustrate the idea.

## Changes

- Make `ENodeOrVar::Var(V)`, adding a generic V in place of `Var(GlobalSymbol)`
- all the associated fallout of adding a generic across the type signatures in the codebase (Note though that no existing test needed to be changed to support this, as `V` defaults to `Var`)
- Add a "No Strings" test to illustrate and prove the API

## Concerns

### Trait constraints generally 

Trait constraints generally are slapdash and could be reduced, I'll put in the work to clean this up if this approach to the change is approved.

### Adds a constraint to struct definition

I'm not happy about this specific change, hoping it is not needed:

```rs
pub struct SearchMatches<'a, L: Language, V = Var>
where
    V: Clone,
```

### `Explanation::check_rewrite` type inference

For some reason, this caused type inference for `N` to fail in a few spots for`Explanation::check_rewrite()`, so it is explicitly specified here.