### PR TITLE
Translate between EGraph types

### DIFF
--- a/src/eclass.rs
+++ b/src/eclass.rs
@@ -41,6 +41,26 @@ impl<L, D> EClass<L, D> {
     pub fn parents(&self) -> impl ExactSizeIterator<Item = (&L, Id)> {
         self.parents.iter().map(|(node, id)| (node, *id))
     }
+
+    /// Converts an EClass defined for language L into one
+    /// defined for language L2
+    pub fn map<F, L2, D2>(self, mapper: F) -> EClass<L2, D2>
+    where
+        F: Fn(L) -> L2,
+        D2: From<D>,
+        L2: Language,
+    {
+        EClass {
+            id: self.id,
+            nodes: self.nodes.into_iter().map(&mapper).collect(),
+            data: self.data.into(),
+            parents: self
+                .parents
+                .into_iter()
+                .map(|(l, id)| (mapper(l), id))
+                .collect(),
+        }
+    }
 }
 
 impl<L: Language, D> EClass<L, D> {

--- a/src/eclass.rs
+++ b/src/eclass.rs
@@ -41,26 +41,6 @@ impl<L, D> EClass<L, D> {
     pub fn parents(&self) -> impl ExactSizeIterator<Item = (&L, Id)> {
         self.parents.iter().map(|(node, id)| (node, *id))
     }
-
-    /// Converts an EClass defined for language L into one
-    /// defined for language L2
-    pub fn map<F, L2, D2>(self, mapper: F) -> EClass<L2, D2>
-    where
-        F: Fn(L) -> L2,
-        D2: From<D>,
-        L2: Language,
-    {
-        EClass {
-            id: self.id,
-            nodes: self.nodes.into_iter().map(&mapper).collect(),
-            data: self.data.into(),
-            parents: self
-                .parents
-                .into_iter()
-                .map(|(l, id)| (mapper(l), id))
-                .collect(),
-        }
-    }
 }
 
 impl<L: Language, D> EClass<L, D> {

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -536,8 +536,11 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     where
         F: Fn(L) -> L2,
         L2: Language,
-        <L2 as Language>::Discriminant: From<<L as Language>::Discriminant>,
+        // `N2` has to be an analysis over `L2`, and be able to be built from `N`
         N2: Analysis<L2> + From<N>,
+        // we need to be able to convert from `L::Discriminant` to `L2::Discriminant`
+        <L2 as Language>::Discriminant: From<<L as Language>::Discriminant>,
+        // we need to be able to convert `L::Data` to `L2::Data`
         <N2 as Analysis<L2>>::Data: From<<N as Analysis<L>>::Data>,
     {
         let kv_map = |(k, v): (L, Id)| ((&lang_mapper)(k), v);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub(crate) use {explain::Explain, unionfind::UnionFind};
 pub use {
     dot::Dot,
     eclass::EClass,
-    egraph::EGraph,
+    egraph::{EGraph, LanguageMapper, SimpleLanguageMapper},
     explain::{
         Explanation, FlatExplanation, FlatTerm, Justification, TreeExplanation, TreeTerm,
         UnionEqualities,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, iter::FromIterator};
 use symbolic_expressions::Sexp;
 
 use fmt::{Debug, Display, Formatter};
@@ -170,5 +170,31 @@ where
         let r = self.queue.is_empty();
         debug_assert_eq!(r, self.set.is_empty());
         r
+    }
+}
+
+impl<T> IntoIterator for UniqueQueue<T>
+where
+    T: Eq + std::hash::Hash + Clone,
+{
+    type Item = T;
+
+    type IntoIter = <std::collections::VecDeque<T> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.queue.into_iter()
+    }
+}
+
+impl<A> FromIterator<A> for UniqueQueue<A>
+where
+    A: Eq + std::hash::Hash + Clone,
+{
+    fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
+        let mut queue = UniqueQueue::default();
+        for t in iter {
+            queue.insert(t);
+        }
+        queue
     }
 }


### PR DESCRIPTION
Addresses issue #305.

I use some pretty complicated trait bounds in the `EGraph::map` function to handle converting between analyses. If the analysis stays the same (`EGraph<L, T> -> EGraph<L2, T>`) these are automatically implemented which makes it more convenient to use in what I imagine is the common case. However, let me know if you think the conversion should be explicitly handled with a passed in closure.