### PR TITLE
Rename `RecExpr` to `Expr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "egg"
 readme = "README.md"
 repository = "https://github.com/egraphs-good/egg"
-version = "0.9.5"
+version = "0.10.0"
 
 [dependencies]
 env_logger = { version = "0.9.0", default-features = false }

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -344,7 +344,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Calling this function on an uncanonical `Id` returns a representative based on the how it
     /// was obtained (see [`add_uncanoncial`](EGraph::add_uncanonical),
     /// [`add_expr_uncanonical`](EGraph::add_expr_uncanonical))
-    pub fn id_to_expr(&self, id: Id) -> RecExpr<L> {
+    pub fn id_to_expr(&self, id: Id) -> Expr<L> {
         let mut res = Default::default();
         let mut cache = Default::default();
         self.id_to_expr_internal(&mut res, id, &mut cache);
@@ -353,7 +353,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
     fn id_to_expr_internal(
         &self,
-        res: &mut RecExpr<L>,
+        res: &mut Expr<L>,
         node_id: Id,
         cache: &mut HashMap<Id, Id>,
     ) -> Id {
@@ -460,8 +460,8 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// given by [`get_flat_string`](Explanation::get_flat_string) and [`get_string`](Explanation::get_string).
     pub fn explain_equivalence(
         &mut self,
-        left_expr: &RecExpr<L>,
-        right_expr: &RecExpr<L>,
+        left_expr: &Expr<L>,
+        right_expr: &Expr<L>,
     ) -> Explanation<L> {
         let left = self.add_expr_uncanonical(left_expr);
         let right = self.add_expr_uncanonical(right_expr);
@@ -503,7 +503,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// into the egraph and ends with the given `expr`.
     /// Note that this function can be called again to explain any intermediate terms
     /// used in the output [`Explanation`].
-    pub fn explain_existance(&mut self, expr: &RecExpr<L>) -> Explanation<L> {
+    pub fn explain_existance(&mut self, expr: &Expr<L>) -> Explanation<L> {
         let id = self.add_expr_uncanonical(expr);
         self.explain_existance_id(id)
     }
@@ -535,7 +535,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Get an explanation for why an expression matches a pattern.
     pub fn explain_matches(
         &mut self,
-        left_expr: &RecExpr<L>,
+        left_expr: &Expr<L>,
         right_pattern: &PatternAst<L>,
         subst: &Subst,
     ) -> Explanation<L> {
@@ -825,7 +825,7 @@ impl<L: Language, N: Analysis<L>> std::ops::IndexMut<Id> for EGraph<L, N> {
 }
 
 impl<L: Language, N: Analysis<L>> EGraph<L, N> {
-    /// Adds a [`RecExpr`] to the [`EGraph`], returning the id of the RecExpr's eclass.
+    /// Adds a [`Expr`] to the [`EGraph`], returning the id of the Expr's eclass.
     ///
     /// # Example
     /// ```
@@ -839,7 +839,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// ```
     ///
     /// [`add_expr`]: EGraph::add_expr()
-    pub fn add_expr(&mut self, expr: &RecExpr<L>) -> Id {
+    pub fn add_expr(&mut self, expr: &Expr<L>) -> Id {
         let id = self.add_expr_uncanonical(expr);
         self.find(id)
     }
@@ -847,7 +847,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Similar to [`add_expr`](EGraph::add_expr) but the `Id` returned may not be canonical
     ///
     /// Calling [`id_to_expr`](EGraph::id_to_expr) on this `Id` return a copy of `expr` when explanations are enabled
-    pub fn add_expr_uncanonical(&mut self, expr: &RecExpr<L>) -> Id {
+    pub fn add_expr_uncanonical(&mut self, expr: &Expr<L>) -> Id {
         let nodes = expr.as_ref();
         let mut new_ids = Vec::with_capacity(nodes.len());
         let mut new_node_q = Vec::with_capacity(nodes.len());
@@ -962,16 +962,16 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         self.memo.get(enode).copied()
     }
 
-    /// Lookup the eclass of the given [`RecExpr`].
+    /// Lookup the eclass of the given [`Expr`].
     ///
     /// Equivalent to the last value in [`EGraph::lookup_expr_ids`].
-    pub fn lookup_expr(&self, expr: &RecExpr<L>) -> Option<Id> {
+    pub fn lookup_expr(&self, expr: &Expr<L>) -> Option<Id> {
         self.lookup_expr_ids(expr)
             .and_then(|ids| ids.last().copied())
     }
 
-    /// Lookup the eclasses of all the nodes in the given [`RecExpr`].
-    pub fn lookup_expr_ids(&self, expr: &RecExpr<L>) -> Option<Vec<Id>> {
+    /// Lookup the eclasses of all the nodes in the given [`Expr`].
+    pub fn lookup_expr_ids(&self, expr: &Expr<L>) -> Option<Vec<Id>> {
         let nodes = expr.as_ref();
         let mut new_ids = Vec::with_capacity(nodes.len());
         for node in nodes {
@@ -1099,11 +1099,11 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         id
     }
 
-    /// Checks whether two [`RecExpr`]s are equivalent.
+    /// Checks whether two [`Expr`]s are equivalent.
     /// Returns a list of id where both expression are represented.
     /// In most cases, there will none or exactly one id.
     ///
-    pub fn equivs(&self, expr1: &RecExpr<L>, expr2: &RecExpr<L>) -> Vec<Id> {
+    pub fn equivs(&self, expr1: &Expr<L>, expr2: &Expr<L>) -> Vec<Id> {
         let pat1 = Pattern::from(expr1.as_ref());
         let pat2 = Pattern::from(expr2.as_ref());
         let matches1 = pat1.search(self);

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -834,8 +834,8 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// let x = egraph.add(S::leaf("x"));
     /// let y = egraph.add(S::leaf("y"));
     /// let plus = egraph.add(S::new("+", vec![x, y]));
-    /// let plus_recexpr = "(+ x y)".parse().unwrap();
-    /// assert_eq!(plus, egraph.add_expr(&plus_recexpr));
+    /// let plus_expr = "(+ x y)".parse().unwrap();
+    /// assert_eq!(plus, egraph.add_expr(&plus_expr));
     /// ```
     ///
     /// [`add_expr`]: EGraph::add_expr()

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -703,7 +703,7 @@ impl<L: Language + Display + FromOp> FlatTerm<L> {
     }
 
     /// Convert this FlatTerm to a RecExpr.
-    pub fn get_recexpr(&self) -> RecExpr<L> {
+    pub fn get_expr(&self) -> RecExpr<L> {
         self.remove_rewrites().to_string().parse().unwrap()
     }
 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,7 +1,7 @@
 use crate::Symbol;
 use crate::{
     util::pretty_print, Analysis, EClass, ENodeOrVar, FromOp, HashMap, HashSet, Id, Language,
-    PatternAst, RecExpr, Rewrite, UnionFind, Var,
+    PatternAst, Expr, Rewrite, UnionFind, Var,
 };
 use saturating::Saturating;
 use std::cmp::Ordering;
@@ -702,8 +702,8 @@ impl<L: Language + Display + FromOp> FlatTerm<L> {
         expr
     }
 
-    /// Convert this FlatTerm to a RecExpr.
-    pub fn get_expr(&self) -> RecExpr<L> {
+    /// Convert this FlatTerm to a Expr.
+    pub fn get_expr(&self) -> Expr<L> {
         self.remove_rewrites().to_string().parse().unwrap()
     }
 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,7 +1,7 @@
 use crate::Symbol;
 use crate::{
-    util::pretty_print, Analysis, EClass, ENodeOrVar, FromOp, HashMap, HashSet, Id, Language,
-    PatternAst, Expr, Rewrite, UnionFind, Var,
+    util::pretty_print, Analysis, EClass, ENodeOrVar, Expr, FromOp, HashMap, HashSet, Id, Language,
+    PatternAst, Rewrite, UnionFind, Var,
 };
 use saturating::Saturating;
 use std::cmp::Ordering;

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use crate::util::HashMap;
-use crate::{Analysis, EClass, EGraph, Id, Language, Expr};
+use crate::{Analysis, EClass, EGraph, Expr, Id, Language};
 
 /** Extracting a single [`Expr`] from an [`EGraph`].
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -224,7 +224,7 @@ where
     /// given eclass.
     pub fn find_best(&self, eclass: Id) -> (CF::Cost, RecExpr<L>) {
         let (cost, root) = self.costs[&self.egraph.find(eclass)].clone();
-        let expr = root.build_recexpr(|id| self.find_best_node(id).clone());
+        let expr = root.build_expr(|id| self.find_best_node(id).clone());
         (cost, expr)
     }
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -363,14 +363,14 @@ impl LanguageChildren for Id {
     fn as_mut_slice(&mut self) -> &mut [Id]  { std::slice::from_mut(self) }
 }
 
-/// A recursive expression from a user-defined [`Language`].
+/// An expression from a user-defined [`Language`].
 ///
-/// This conceptually represents a recursive expression, but it's actually just
+/// This conceptually represents an expression, but it's actually just
 /// a list of enodes.
 ///
 /// [`Expr`]s must satisfy the invariant that enodes' children must refer to
 /// elements that come before it in the list. For example, the expression
-/// `(+ (* x 5) x)` could be represented by a recursive expression of the form
+/// `(+ (* x 5) x)` could be represented by an expression of the form
 /// `[Num(5), Var("x"), Mul(1, 0), Add(2, 1)]`.
 ///
 /// If the `serde-1` feature is enabled, this implements

--- a/src/lp_extract.rs
+++ b/src/lp_extract.rs
@@ -155,12 +155,12 @@ where
     /// Extract a single rooted term.
     ///
     /// This is just a shortcut for [`LpExtractor::solve_multiple`].
-    pub fn solve(&mut self, root: Id) -> RecExpr<L> {
+    pub fn solve(&mut self, root: Id) -> Expr<L> {
         self.solve_multiple(&[root]).0
     }
 
     /// Extract (potentially multiple) roots
-    pub fn solve_multiple(&mut self, roots: &[Id]) -> (RecExpr<L>, Vec<Id>) {
+    pub fn solve_multiple(&mut self, roots: &[Id]) -> (Expr<L>, Vec<Id>) {
         let egraph = self.egraph;
 
         for class in self.vars.values() {
@@ -180,7 +180,7 @@ where
         );
 
         let mut todo: Vec<Id> = roots.iter().map(|id| self.egraph.find(*id)).collect();
-        let mut expr = RecExpr::default();
+        let mut expr = Expr::default();
         // converts e-class ids to e-node ids
         let mut ids: HashMap<Id, Id> = HashMap::default();
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -63,14 +63,14 @@ use crate::*;
 /// [`FromStr`]: std::str::FromStr
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Pattern<L> {
-    /// The actual pattern as a [`RecExpr`]
+    /// The actual pattern as a [`Expr`]
     pub ast: PatternAst<L>,
     program: machine::Program<L>,
 }
 
-/// A [`RecExpr`] that represents a
+/// A [`Expr`] that represents a
 /// [`Pattern`].
-pub type PatternAst<L> = RecExpr<ENodeOrVar<L>>;
+pub type PatternAst<L> = Expr<ENodeOrVar<L>>;
 
 impl<L: Language> PatternAst<L> {
     /// Returns a new `PatternAst` with the variables renames canonically
@@ -216,7 +216,7 @@ impl<L: FromOp> FromOp for ENodeOrVar<L> {
 }
 
 impl<L: FromOp> std::str::FromStr for Pattern<L> {
-    type Err = RecExprParseError<ENodeOrVarParseError<L::Error>>;
+    type Err = ExprParseError<ENodeOrVarParseError<L::Error>>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         PatternAst::from_str(s).map(Self::from)
@@ -226,13 +226,13 @@ impl<L: FromOp> std::str::FromStr for Pattern<L> {
 impl<'a, L: Language> From<&'a [L]> for Pattern<L> {
     fn from(expr: &'a [L]) -> Self {
         let nodes: Vec<_> = expr.iter().cloned().map(ENodeOrVar::ENode).collect();
-        let ast = RecExpr::from(nodes);
+        let ast = Expr::from(nodes);
         Self::new(ast)
     }
 }
 
-impl<L: Language> From<&RecExpr<L>> for Pattern<L> {
-    fn from(expr: &RecExpr<L>) -> Self {
+impl<L: Language> From<&Expr<L>> for Pattern<L> {
+    fn from(expr: &Expr<L>) -> Self {
         Self::from(expr.as_ref())
     }
 }
@@ -243,7 +243,7 @@ impl<L: Language> From<PatternAst<L>> for Pattern<L> {
     }
 }
 
-impl<L: Language> TryFrom<Pattern<L>> for RecExpr<L> {
+impl<L: Language> TryFrom<Pattern<L>> for Expr<L> {
     type Error = Var;
     fn try_from(pat: Pattern<L>) -> Result<Self, Self::Error> {
         let nodes = pat.ast.as_ref().iter().cloned();
@@ -253,7 +253,7 @@ impl<L: Language> TryFrom<Pattern<L>> for RecExpr<L> {
                 ENodeOrVar::Var(v) => Err(v),
             })
             .collect();
-        ns.map(RecExpr::from)
+        ns.map(Expr::from)
     }
 }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -589,8 +589,8 @@ mod tests {
         crate::init_logger();
         let mut egraph = EGraph::default();
 
-        let start = RecExpr::from_str("(+ x y)").unwrap();
-        let goal = RecExpr::from_str("xy").unwrap();
+        let start = Expr::from_str("(+ x y)").unwrap();
+        let goal = Expr::from_str("xy").unwrap();
 
         let root = egraph.add_expr(&start);
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -388,7 +388,7 @@ where
     /// The eclass id of this addition will be recorded in the
     /// [`roots`](Runner::roots) field, ordered by
     /// insertion order.
-    pub fn with_expr(mut self, expr: &RecExpr<L>) -> Self {
+    pub fn with_expr(mut self, expr: &Expr<L>) -> Self {
         let id = self.egraph.add_expr(expr);
         self.roots.push(id);
         self
@@ -458,12 +458,12 @@ where
     }
 
     /// Calls [`EGraph::explain_equivalence`](EGraph::explain_equivalence()).
-    pub fn explain_equivalence(&mut self, left: &RecExpr<L>, right: &RecExpr<L>) -> Explanation<L> {
+    pub fn explain_equivalence(&mut self, left: &Expr<L>, right: &Expr<L>) -> Explanation<L> {
         self.egraph.explain_equivalence(left, right)
     }
 
     /// Calls [`EGraph::explain_existance`](EGraph::explain_existance()).
-    pub fn explain_existance(&mut self, expr: &RecExpr<L>) -> Explanation<L> {
+    pub fn explain_existance(&mut self, expr: &Expr<L>) -> Explanation<L> {
         self.egraph.explain_existance(expr)
     }
 
@@ -479,7 +479,7 @@ where
     /// Get an explanation for why an expression matches a pattern.
     pub fn explain_matches(
         &mut self,
-        left: &RecExpr<L>,
+        left: &Expr<L>,
         right: &PatternAst<L>,
         subst: &Subst,
     ) -> Explanation<L> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,7 +31,7 @@ pub fn test_runner<L, A>(
     name: &str,
     runner: Option<Runner<L, A, ()>>,
     rules: &[Rewrite<L, A>],
-    start: RecExpr<L>,
+    start: Expr<L>,
     goals: &[Pattern<L>],
     check_fn: Option<fn(Runner<L, A, ()>)>,
     should_check: bool,

--- a/src/tutorials/_02_getting_started.rs
+++ b/src/tutorials/_02_getting_started.rs
@@ -55,16 +55,16 @@ An e-node may have any number of children, which are [`Id`]s.
 An [`Id`] is basically just a number that `egg` uses to coordinate what children
   an e-node is associated with.
 In an [`EGraph`], e-node children refer to e-classes.
-In a [`RecExpr`] (`egg`'s version of a plain old expression),
-  e-node children refer to other e-nodes in that [`RecExpr`].
+In a [`Expr`] (`egg`'s version of a plain old expression),
+  e-node children refer to other e-nodes in that [`Expr`].
 
 Most [`Language`]s, including [`SymbolLang`], can be parsed and pretty-printed.
-That means that [`RecExpr`]s in those languages
+That means that [`Expr`]s in those languages
   implement the [`FromStr`] and [`Display`] traits from the Rust standard library.
 ```
 # use egg::*;
 // Since parsing can return an error, `unwrap` just panics if the result doesn't return Ok
-let my_expression: RecExpr<SymbolLang> = "(foo a b)".parse().unwrap();
+let my_expression: Expr<SymbolLang> = "(foo a b)".parse().unwrap();
 println!("this is my expression {}", my_expression);
 
 // let's try to create an e-node, but hmmm, what do I put as the children?
@@ -74,11 +74,11 @@ let my_enode = SymbolLang::new("bar", vec![]);
 Some e-nodes are just constants and have no children (also called leaves).
 But it's intentionally kind of awkward to create e-nodes with children in isolation,
   since you would have to add meaningless [`Id`]s as children.
-The way to make meaningful [`Id`]s is by adding e-nodes to either an [`EGraph`] or a [`RecExpr`]:
+The way to make meaningful [`Id`]s is by adding e-nodes to either an [`EGraph`] or a [`Expr`]:
 
 ```
 # use egg::*;
-let mut expr = RecExpr::default();
+let mut expr = Expr::default();
 let a = expr.add(SymbolLang::leaf("a"));
 let b = expr.add(SymbolLang::leaf("b"));
 let foo = expr.add(SymbolLang::new("foo", vec![a, b]));
@@ -89,7 +89,7 @@ let a = egraph.add(SymbolLang::leaf("a"));
 let b = egraph.add(SymbolLang::leaf("b"));
 let foo = egraph.add(SymbolLang::new("foo", vec![a, b]));
 
-// we can also add RecExprs to an egraph
+// we can also add Exprs to an egraph
 let foo2 = egraph.add_expr(&expr);
 // note that if you add the same thing to an e-graph twice, you'll get back equivalent Ids
 assert_eq!(foo, foo2);
@@ -112,7 +112,7 @@ let foo = egraph.add(SymbolLang::new("foo", vec![a, b]));
 // rebuild the e-graph since we modified it
 egraph.rebuild();
 
-// we can make Patterns by parsing, similar to RecExprs
+// we can make Patterns by parsing, similar to Exprs
 // names preceded by ? are parsed as Pattern variables and will match anything
 let pat: Pattern<SymbolLang> = "(foo ?x ?x)".parse().unwrap();
 
@@ -134,7 +134,7 @@ assert!(!matches.is_empty());
 
 ## Using [`Runner`] to make an optimizer
 
-Now that we can make [`Pattern`]s and work with [`RecExpr`]s, we can make an optimizer!
+Now that we can make [`Pattern`]s and work with [`Expr`]s, we can make an optimizer!
 We'll use the [`rewrite!`] macro to easily create [`Rewrite`]s which consist of a name,
   left-hand pattern to search for,
   and right-hand pattern to apply.
@@ -179,7 +179,7 @@ assert_eq!(best_cost, 1);
 [`Language`]: super::super::Language
 [`Searcher`]: super::super::Searcher
 [`Pattern`]: super::super::Pattern
-[`RecExpr`]: super::super::RecExpr
+[`Expr`]: super::super::Expr
 [`SymbolLang`]: super::super::SymbolLang
 [`define_language!`]: super::super::define_language!
 [`rewrite!`]: super::super::rewrite!

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -310,7 +310,7 @@ egg::test_fn! {
 
 #[test]
 fn assoc_mul_saturates() {
-    let expr: RecExpr<Math> = "(* x 1)".parse().unwrap();
+    let expr: Expr<Math> = "(* x 1)".parse().unwrap();
 
     let runner: Runner<Math, ConstantFold> = Runner::default()
         .with_iter_limit(3)
@@ -322,7 +322,7 @@ fn assoc_mul_saturates() {
 
 #[test]
 fn test_union_trusted() {
-    let expr: RecExpr<Math> = "(+ (* x 1) y)".parse().unwrap();
+    let expr: Expr<Math> = "(+ (* x 1) y)".parse().unwrap();
     let expr2 = "20".parse().unwrap();
     let mut runner: Runner<Math, ConstantFold> = Runner::default()
         .with_explanations_enabled()
@@ -339,7 +339,7 @@ fn test_union_trusted() {
 #[cfg(feature = "lp")]
 #[test]
 fn math_lp_extract() {
-    let expr: RecExpr<Math> = "(pow (+ x (+ x x)) (+ x x))".parse().unwrap();
+    let expr: Expr<Math> = "(pow (+ x (+ x x)) (+ x x))".parse().unwrap();
 
     let runner: Runner<Math, ConstantFold> = Runner::default()
         .with_iter_limit(3)

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -100,8 +100,8 @@ fn prove_something(name: &str, start: &str, rewrites: &[Rewrite], goals: &[&str]
     let _ = env_logger::builder().is_test(true).try_init();
     println!("Proving {}", name);
 
-    let start_expr: RecExpr<_> = start.parse().unwrap();
-    let goal_exprs: Vec<RecExpr<_>> = goals.iter().map(|g| g.parse().unwrap()).collect();
+    let start_expr: Expr<_> = start.parse().unwrap();
+    let goal_exprs: Vec<Expr<_>> = goals.iter().map(|g| g.parse().unwrap()).collect();
 
     let mut runner = Runner::default()
         .with_iter_limit(20)

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -22,7 +22,7 @@ fn make_rules() -> Vec<Rewrite<SimpleLanguage, ()>> {
 /// parse an expression, simplify it using egg, and pretty print it back out
 fn simplify(s: &str) -> String {
     // parse the expression, the type annotation tells it which Language to use
-    let expr: RecExpr<SimpleLanguage> = s.parse().unwrap();
+    let expr: Expr<SimpleLanguage> = s.parse().unwrap();
 
     // simplify the expression using a Runner, which creates an e-graph with
     // the given expression and runs the given rules over it


### PR DESCRIPTION
Renamed everywhere except the changelog.
`recexpr` -> `expr`.
`RecExpr` -> `Expr`.
Increased the crate version to `0.10.0` in Cargo.toml.

To close https://github.com/egraphs-good/egg/issues/37