### PR TITLE
Added `fn root(&self) -> Id` to `RecExpr`.

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -456,6 +456,11 @@ impl<L: Language> RecExpr<L> {
         }
         true
     }
+
+    /// Get the root node of this expression. When adding a new node via `add`, it becomes the new root.
+    pub fn root(&self) -> Id {
+        Id::from(self.nodes.len() - 1)
+    }
 }
 
 impl<L: Language> Index<Id> for RecExpr<L> {


### PR DESCRIPTION
This is a convenience method for getting the root node of an expression for working on `RecExpr` directly without needing to know that it is the last element of it's slice.