### PR TITLE
RecExpr Deref/DerefMut=[L]. also convenience methods and trait impls

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -846,10 +846,9 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     ///
     /// Calling [`id_to_expr`](EGraph::id_to_expr) on this `Id` return a copy of `expr` when explanations are enabled
     pub fn add_expr_uncanonical(&mut self, expr: &RecExpr<L>) -> Id {
-        let nodes = expr.as_ref();
-        let mut new_ids = Vec::with_capacity(nodes.len());
-        let mut new_node_q = Vec::with_capacity(nodes.len());
-        for node in nodes {
+        let mut new_ids = Vec::with_capacity(expr.len());
+        let mut new_node_q = Vec::with_capacity(expr.len());
+        for node in expr {
             let new_node = node.clone().map_children(|i| new_ids[usize::from(i)]);
             let size_before = self.unionfind.size();
             let next_id = self.add_uncanonical(new_node);
@@ -885,10 +884,9 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Calling [`id_to_expr`](EGraph::id_to_expr) on this `Id` return an correspond to the
     /// instantiation of the pattern
     fn add_instantiation_noncanonical(&mut self, pat: &PatternAst<L>, subst: &Subst) -> Id {
-        let nodes = pat.as_ref();
-        let mut new_ids = Vec::with_capacity(nodes.len());
-        let mut new_node_q = Vec::with_capacity(nodes.len());
-        for node in nodes {
+        let mut new_ids = Vec::with_capacity(pat.len());
+        let mut new_node_q = Vec::with_capacity(pat.len());
+        for node in pat {
             match node {
                 ENodeOrVar::Var(var) => {
                     let id = self.find(subst[*var]);
@@ -970,9 +968,8 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
 
     /// Lookup the eclasses of all the nodes in the given [`RecExpr`].
     pub fn lookup_expr_ids(&self, expr: &RecExpr<L>) -> Option<Vec<Id>> {
-        let nodes = expr.as_ref();
-        let mut new_ids = Vec::with_capacity(nodes.len());
-        for node in nodes {
+        let mut new_ids = Vec::with_capacity(expr.len());
+        for node in expr {
             let node = node.clone().map_children(|i| new_ids[usize::from(i)]);
             let id = self.lookup(node)?;
             new_ids.push(id)
@@ -1102,8 +1099,8 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// In most cases, there will none or exactly one id.
     ///
     pub fn equivs(&self, expr1: &RecExpr<L>, expr2: &RecExpr<L>) -> Vec<Id> {
-        let pat1 = Pattern::from(expr1.as_ref());
-        let pat2 = Pattern::from(expr2.as_ref());
+        let pat1 = Pattern::from(expr1);
+        let pat2 = Pattern::from(expr2);
         let matches1 = pat1.search(self);
         trace!("Matches1: {:?}", matches1);
 

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -793,11 +793,9 @@ impl<L: Language> FlatTerm<L> {
     /// Rewrite the FlatTerm by matching the lhs and substituting the rhs.
     /// The lhs must be guaranteed to match.
     pub fn rewrite(&self, lhs: &PatternAst<L>, rhs: &PatternAst<L>) -> FlatTerm<L> {
-        let lhs_nodes = lhs.as_ref();
-        let rhs_nodes = rhs.as_ref();
         let mut bindings = Default::default();
-        self.make_bindings(lhs_nodes, lhs_nodes.len() - 1, &mut bindings);
-        FlatTerm::from_pattern(rhs_nodes, rhs_nodes.len() - 1, &bindings)
+        self.make_bindings(lhs, lhs.len() - 1, &mut bindings);
+        FlatTerm::from_pattern(rhs, rhs.len() - 1, &bindings)
     }
 
     /// Checks if this term or any child has a [`forward_rule`](FlatTerm::forward_rule).

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -134,14 +134,13 @@ pub trait CostFunction<L: Language> {
     /// down the [`RecExpr`].
     ///
     fn cost_rec(&mut self, expr: &RecExpr<L>) -> Self::Cost {
-        let nodes = expr.as_ref();
-        let mut costs = hashmap_with_capacity::<Id, Self::Cost>(nodes.len());
-        for (i, node) in nodes.iter().enumerate() {
+        let mut costs = hashmap_with_capacity::<Id, Self::Cost>(expr.len());
+        for (i, node) in expr.items() {
             let cost = self.cost(node, |i| costs[&i].clone());
-            costs.insert(Id::from(i), cost);
+            costs.insert(i, cost);
         }
-        let last_id = Id::from(expr.as_ref().len() - 1);
-        costs[&last_id].clone()
+        let root = expr.root();
+        costs[&root].clone()
     }
 }
 

--- a/src/lp_extract.rs
+++ b/src/lp_extract.rs
@@ -52,7 +52,7 @@ impl<L: Language, N: Analysis<L>> LpCostFunction<L, N> for AstSize {
 /// // Using ILP only counts common sub-expressions once,
 /// // so it can lead to a smaller DAG expression.
 /// assert_eq!(lp_best.to_string(), "(f x x x)");
-/// assert_eq!(lp_best.as_ref().len(), 2);
+/// assert_eq!(lp_best.len(), 2);
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "lp")))]
 pub struct LpExtractor<'a, L: Language, N: Analysis<L>> {
@@ -260,7 +260,7 @@ mod tests {
         let (exp, ids) = ext.solve_multiple(&[f, g]);
         println!("{:?}", exp);
         println!("{}", exp);
-        assert_eq!(exp.as_ref().len(), 4);
+        assert_eq!(exp.len(), 4);
         assert_eq!(ids.len(), 2);
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -190,11 +190,11 @@ impl<L: Language> Compiler<L> {
     }
 
     fn load_pattern(&mut self, pattern: &PatternAst<L>) {
-        let len = pattern.as_ref().len();
+        let len = pattern.len();
         self.free_vars = Vec::with_capacity(len);
         self.subtree_size = Vec::with_capacity(len);
 
-        for node in pattern.as_ref() {
+        for node in pattern {
             let mut free = HashSet::default();
             let mut size = 0;
             match node {
@@ -247,7 +247,7 @@ impl<L: Language> Compiler<L> {
 
     fn compile(&mut self, patternbinder: Option<Var>, pattern: &PatternAst<L>) {
         self.load_pattern(pattern);
-        let last_i = pattern.as_ref().len() - 1;
+        let root = pattern.root();
 
         let mut next_out = self.next_reg;
 
@@ -259,13 +259,13 @@ impl<L: Language> Compiler<L> {
                 comp.instructions
                     .push(Instruction::Scan { out: comp.next_reg });
             }
-            comp.add_todo(pattern, Id::from(last_i), comp.next_reg);
+            comp.add_todo(pattern, root, comp.next_reg);
         };
 
         if let Some(v) = patternbinder {
             if let Some(&i) = self.v2r.get(&v) {
                 // patternbinder already bound
-                self.add_todo(pattern, Id::from(last_i), i);
+                self.add_todo(pattern, root, i);
             } else {
                 // patternbinder is new variable
                 next_out.0 += 1;
@@ -284,7 +284,6 @@ impl<L: Language> Compiler<L> {
                 self.instructions.push(Instruction::Lookup {
                     i: reg,
                     term: extracted
-                        .as_ref()
                         .iter()
                         .map(|n| match n {
                             ENodeOrVar::ENode(n) => ENodeOrReg::ENode(n.clone()),

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -110,7 +110,7 @@ impl<L: Language, A: Analysis<L>> Searcher<L, A> for MultiPattern<L> {
         match self.asts.as_slice() {
             [] => panic!("empty multipattern"),
             [(_var, pat), ..] => {
-                if let [ENodeOrVar::Var(_)] = pat.as_ref() {
+                if let [ENodeOrVar::Var(_)] = **pat {
                     panic!(
                         "Bare cannot be first pattern variable in multipattern: {:?}",
                         self.asts
@@ -134,7 +134,7 @@ impl<L: Language, A: Analysis<L>> Searcher<L, A> for MultiPattern<L> {
         let mut vars = vec![];
         for (v, pat) in &self.asts {
             vars.push(*v);
-            for n in pat.as_ref() {
+            for n in pat {
                 if let ENodeOrVar::Var(v) = n {
                     vars.push(*v)
                 }
@@ -172,8 +172,8 @@ impl<L: Language, A: Analysis<L>> Applier<L, A> for MultiPattern<L> {
                 let mut subst = subst.clone();
                 let mut id_buf = vec![];
                 for (i, (v, p)) in self.asts.iter().enumerate() {
-                    id_buf.resize(p.as_ref().len(), 0.into());
-                    let id1 = crate::pattern::apply_pat(&mut id_buf, p.as_ref(), egraph, &subst);
+                    id_buf.resize(p.len(), 0.into());
+                    let id1 = crate::pattern::apply_pat(&mut id_buf, p, egraph, &subst);
                     if let Some(id2) = subst.insert(*v, id1) {
                         egraph.union(id1, id2);
                     }
@@ -190,7 +190,7 @@ impl<L: Language, A: Analysis<L>> Applier<L, A> for MultiPattern<L> {
         let mut bound_vars = HashSet::default();
         let mut vars = vec![];
         for (bv, pat) in &self.asts {
-            for n in pat.as_ref() {
+            for n in pat {
                 if let ENodeOrVar::Var(v) = n {
                     // using vars that are already bound doesn't count
                     if !bound_vars.contains(v) {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,6 +1,7 @@
 use fmt::Formatter;
 use log::*;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::fmt::{self, Display};
 use std::{convert::TryFrom, str::FromStr};
 
@@ -86,7 +87,7 @@ impl<L: Language> PatternAst<L> {
             }
         }
 
-        for n in self.as_ref() {
+        for n in self {
             new.add(match n {
                 ENodeOrVar::ENode(_) => n.clone(),
                 ENodeOrVar::Var(v) => {
@@ -111,7 +112,7 @@ impl<L: Language> Pattern<L> {
     /// Returns a list of the [`Var`]s in this pattern.
     pub fn vars(&self) -> Vec<Var> {
         let mut vars = vec![];
-        for n in self.ast.as_ref() {
+        for n in &self.ast {
             if let ENodeOrVar::Var(v) = n {
                 if !vars.contains(v) {
                     vars.push(*v)
@@ -225,8 +226,14 @@ impl<L: FromOp> std::str::FromStr for Pattern<L> {
 
 impl<'a, L: Language> From<&'a [L]> for Pattern<L> {
     fn from(expr: &'a [L]) -> Self {
-        let nodes: Vec<_> = expr.iter().cloned().map(ENodeOrVar::ENode).collect();
-        let ast = RecExpr::from(nodes);
+        let ast = expr.iter().cloned().map(ENodeOrVar::ENode).collect();
+        Self::new(ast)
+    }
+}
+
+impl<L: Language> From<RecExpr<L>> for Pattern<L> {
+    fn from(expr: RecExpr<L>) -> Self {
+        let ast = expr.into_iter().map(ENodeOrVar::ENode).collect();
         Self::new(ast)
     }
 }
@@ -243,17 +250,22 @@ impl<L: Language> From<PatternAst<L>> for Pattern<L> {
     }
 }
 
-impl<L: Language> TryFrom<Pattern<L>> for RecExpr<L> {
+impl<L: Language> TryFrom<PatternAst<L>> for RecExpr<L> {
     type Error = Var;
-    fn try_from(pat: Pattern<L>) -> Result<Self, Self::Error> {
-        let nodes = pat.ast.as_ref().iter().cloned();
-        let ns: Result<Vec<_>, _> = nodes
+    fn try_from(ast: PatternAst<L>) -> Result<Self, Self::Error> {
+        ast.into_iter()
             .map(|n| match n {
                 ENodeOrVar::ENode(n) => Ok(n),
                 ENodeOrVar::Var(v) => Err(v),
             })
-            .collect();
-        ns.map(RecExpr::from)
+            .collect()
+    }
+}
+
+impl<L: Language> TryFrom<Pattern<L>> for RecExpr<L> {
+    type Error = Var;
+    fn try_from(pat: Pattern<L>) -> Result<Self, Self::Error> {
+        pat.ast.try_into()
     }
 }
 
@@ -286,7 +298,7 @@ impl<L: Language, A: Analysis<L>> Searcher<L, A> for Pattern<L> {
     }
 
     fn search_with_limit(&self, egraph: &EGraph<L, A>, limit: usize) -> Vec<SearchMatches<L>> {
-        match self.ast.as_ref().last().unwrap() {
+        match self.ast.last().unwrap() {
             ENodeOrVar::ENode(e) => {
                 let key = e.discriminant();
                 match egraph.classes_by_op.get(&key) {
@@ -348,8 +360,7 @@ where
         rule_name: Symbol,
     ) -> Vec<Id> {
         let mut added = vec![];
-        let ast = self.ast.as_ref();
-        let mut id_buf = vec![0.into(); ast.len()];
+        let mut id_buf = vec![0.into(); self.ast.len()];
         for mat in matches {
             let sast = mat.ast.as_ref().map(|cow| cow.as_ref());
             for subst in &mat.substs {
@@ -361,7 +372,7 @@ where
                     did_something = did_something_temp;
                     id = id_temp;
                 } else {
-                    id = apply_pat(&mut id_buf, ast, egraph, subst);
+                    id = apply_pat(&mut id_buf, &self.ast, egraph, subst);
                     did_something = egraph.union(id, mat.eclass);
                 }
 
@@ -381,9 +392,8 @@ where
         searcher_ast: Option<&PatternAst<L>>,
         rule_name: Symbol,
     ) -> Vec<Id> {
-        let ast = self.ast.as_ref();
-        let mut id_buf = vec![0.into(); ast.len()];
-        let id = apply_pat(&mut id_buf, ast, egraph, subst);
+        let mut id_buf = vec![0.into(); self.ast.len()];
+        let id = apply_pat(&mut id_buf, &self.ast, egraph, subst);
 
         if let Some(ast) = searcher_ast {
             let (from, did_something) =

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -524,10 +524,10 @@ where
     N: Analysis<L>,
 {
     fn check(&self, egraph: &mut EGraph<L, N>, _eclass: Id, subst: &Subst) -> bool {
-        let mut id_buf_1 = vec![0.into(); self.p1.ast.as_ref().len()];
-        let mut id_buf_2 = vec![0.into(); self.p2.ast.as_ref().len()];
-        let a1 = apply_pat(&mut id_buf_1, self.p1.ast.as_ref(), egraph, subst);
-        let a2 = apply_pat(&mut id_buf_2, self.p2.ast.as_ref(), egraph, subst);
+        let mut id_buf_1 = vec![0.into(); self.p1.ast.len()];
+        let mut id_buf_2 = vec![0.into(); self.p2.ast.len()];
+        let a1 = apply_pat(&mut id_buf_1, &self.p1.ast, egraph, subst);
+        let a2 = apply_pat(&mut id_buf_2, &self.p2.ast, egraph, subst);
         a1 == a2
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -155,10 +155,10 @@ where
 
     eprintln!("{} patterns", patterns.len());
 
-    patterns.retain(|p| p.ast.as_ref().len() > 1);
+    patterns.retain(|p| p.ast.len() > 1);
     patterns.sort_by_key(|p| p.to_string());
     patterns.dedup();
-    patterns.sort_by_key(|p| p.ast.as_ref().len());
+    patterns.sort_by_key(|p| p.ast.len());
 
     let iter_limit = env_var("EGG_ITER_LIMIT").unwrap_or(1);
     let node_limit = env_var("EGG_NODE_LIMIT").unwrap_or(1_000_000);

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -350,12 +350,12 @@ fn math_lp_extract() {
     let best = Extractor::new(&runner.egraph, AstSize).find_best(root).1;
     let lp_best = LpExtractor::new(&runner.egraph, AstSize).solve(root);
 
-    println!("input   [{}] {}", expr.as_ref().len(), expr);
-    println!("normal  [{}] {}", best.as_ref().len(), best);
-    println!("ilp cse [{}] {}", lp_best.as_ref().len(), lp_best);
+    println!("input   [{}] {}", expr.len(), expr);
+    println!("normal  [{}] {}", best.len(), best);
+    println!("ilp cse [{}] {}", lp_best.len(), lp_best);
 
     assert_ne!(best, lp_best);
-    assert_eq!(lp_best.as_ref().len(), 4);
+    assert_eq!(lp_best.len(), 4);
 }
 
 #[test]


### PR DESCRIPTION
I believe the current API of RecExpr already constrains the impl enough to go ahead and add `Deref/DerefMut = [L]`. I could instead add `len`/`iter`/`iter_mut` and still get most of the benefits of `Deref/DerefMut`.

I also added `FromIterator`, `AsMut`, `Borrow`, `BorrowMut`, and `IntoIterator` impls, and a couple of convenience methods. `items` solves the issue of `expr.as_ref().iter().enumerate()` followed by `Id::from(idx)`

I went ahead and changed the source to take advantage of these additions. Let me know if you would like me to scale this pr back.