### PR TITLE
Parallel matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ serde-1 = [
   "vectorize",
 ]
 wasm-bindgen = []
+parallel-matching = ["rayon", "hashbrown/rayon"]
+
 
 # private features for testing
 test-explanations = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,11 @@ serde-1 = [
   "vectorize",
 ]
 wasm-bindgen = []
-parallel-matching = ["rayon", "hashbrown/rayon"]
+parallel-matching = [
+  "rayon",
+  "hashbrown/rayon",
+  "indexmap/rayon"
+]
 
 
 # private features for testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ vectorize = { version = "0.2.0", optional = true }
 serde_json = { version = "1.0.81", optional = true }
 saturating = "0.1.0"
 
+# for parallel matching
+rayon = { version = "1.10.0", optional = true }
+
 [dev-dependencies]
 ordered-float = "3.0.0"
 

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -582,7 +582,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// This is private, but internals should use this whenever
     /// possible because it does path compression.
     fn find_mut(&mut self, id: Id) -> Id {
-        self.unionfind.find_mut(id)
+        self.unionfind.find(id)
     }
 
     /// Creates a [`Dot`] to visualize this egraph. See [`Dot`].
@@ -1308,7 +1308,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             class
                 .nodes
                 .iter_mut()
-                .for_each(|n| n.update_children(|id| uf.find_mut(id)));
+                .for_each(|n| n.update_children(|id| uf.find(id)));
             class.nodes.sort_unstable();
             class.nodes.dedup();
 

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -591,7 +591,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// This is private, but internals should use this whenever
     /// possible because it does path compression.
     fn find_mut(&mut self, id: Id) -> Id {
-        self.unionfind.find(id)
+        self.unionfind.find_mut(id)
     }
 
     /// Creates a [`Dot`] to visualize this egraph. See [`Dot`].
@@ -1317,7 +1317,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             class
                 .nodes
                 .iter_mut()
-                .for_each(|n| n.update_children(|id| uf.find(id)));
+                .for_each(|n| n.update_children(|id| uf.find_mut(id)));
             class.nodes.sort_unstable();
             class.nodes.dedup();
 

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -8,6 +8,9 @@ use std::{
 #[cfg(feature = "serde-1")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "parallel-matching")]
+use rayon::prelude::*;
+
 use log::*;
 
 /** A data structure to keep track of equalities between expressions.
@@ -133,6 +136,12 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Returns an mutating iterator over the eclasses in the egraph.
     pub fn classes_mut(&mut self) -> impl ExactSizeIterator<Item = &mut EClass<L, N::Data>> {
         self.classes.values_mut()
+    }
+
+    /// Returns a parallel iterator over the eclasses in the egraph.
+    #[cfg(feature = "parallel-matching")]
+    pub fn par_classes(&self) -> impl ParallelIterator<Item = &EClass<L, N::Data>> {
+        self.classes.par_values()
     }
 
     /// Returns `true` if the egraph is empty

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1830,14 +1830,14 @@ impl<'x, L: Language> ExplainNodes<'x, L> {
                 common_ancestor,
             );
             unionfind.union(enode, *child);
-            ancestor[usize::from(unionfind.find(enode))] = enode;
+            ancestor[usize::from(unionfind.find_mut(enode))] = enode;
         }
 
         if common_ancestor_queries.get(&enode).is_some() {
             black_set.insert(enode);
             for other in common_ancestor_queries.get(&enode).unwrap() {
                 if black_set.contains(other) {
-                    let ancestor = ancestor[usize::from(unionfind.find(*other))];
+                    let ancestor = ancestor[usize::from(unionfind.find_mut(*other))];
                     common_ancestor.insert((enode, *other), ancestor);
                     common_ancestor.insert((*other, enode), ancestor);
                 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -28,11 +28,11 @@ use thiserror::Error;
 ///
 /// See [`SymbolLang`] for quick-and-dirty use cases.
 #[allow(clippy::len_without_is_empty)]
-pub trait Language: Debug + Clone + Eq + Ord + Hash {
+pub trait Language: Debug + Clone + Eq + Ord + Hash + Send + Sync {
     /// Type representing the cases of this language.
     ///
     /// Used for short-circuiting the search for equivalent nodes.
-    type Discriminant: Debug + Clone + Eq + Hash;
+    type Discriminant: Debug + Clone + Eq + Hash + Send + Sync;
 
     /// Return the `Discriminant` of this node.
     #[allow(enum_intrinsics_non_enums)]
@@ -704,9 +704,9 @@ assert_eq!(runner.egraph.find(runner.roots[0]), runner.egraph.find(just_foo));
 [`math.rs`]: https://github.com/egraphs-good/egg/blob/main/tests/math.rs
 [`prop.rs`]: https://github.com/egraphs-good/egg/blob/main/tests/prop.rs
 */
-pub trait Analysis<L: Language>: Sized {
+pub trait Analysis<L: Language>: Sized + Send + Sync {
     /// The per-[`EClass`] data for this analysis.
-    type Data: Debug;
+    type Data: Debug + Send + Sync;
 
     /// Makes a new [`Analysis`] data for a given e-node.
     ///

--- a/src/language.rs
+++ b/src/language.rs
@@ -28,11 +28,11 @@ use thiserror::Error;
 ///
 /// See [`SymbolLang`] for quick-and-dirty use cases.
 #[allow(clippy::len_without_is_empty)]
-pub trait Language: Debug + Clone + Eq + Ord + Hash + Send + Sync {
+pub trait Language: Debug + Clone + Eq + Ord + Hash + MaybePar {
     /// Type representing the cases of this language.
     ///
     /// Used for short-circuiting the search for equivalent nodes.
-    type Discriminant: Debug + Clone + Eq + Hash + Send + Sync;
+    type Discriminant: Debug + Clone + Eq + Hash + MaybePar;
 
     /// Return the `Discriminant` of this node.
     #[allow(enum_intrinsics_non_enums)]
@@ -704,9 +704,9 @@ assert_eq!(runner.egraph.find(runner.roots[0]), runner.egraph.find(just_foo));
 [`math.rs`]: https://github.com/egraphs-good/egg/blob/main/tests/math.rs
 [`prop.rs`]: https://github.com/egraphs-good/egg/blob/main/tests/prop.rs
 */
-pub trait Analysis<L: Language>: Sized + Send + Sync {
+pub trait Analysis<L: Language>: Sized + MaybePar {
     /// The per-[`EClass`] data for this analysis.
-    type Data: Debug + Send + Sync;
+    type Data: Debug + MaybePar;
 
     /// Makes a new [`Analysis`] data for a given e-node.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,6 @@ for less or more logging.
 #![doc = include_str!("../tests/simple.rs")]
 #![doc = "\n```"]
 
-use std::sync::atomic::{AtomicU32, Ordering};
-
 mod macros;
 
 #[doc(hidden)]
@@ -84,63 +82,6 @@ impl std::fmt::Debug for Id {
 impl std::fmt::Display for Id {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-/// A key to identify [`EClass`]es which can be used in parallel algorithms.
-/// Its underlying type should be the atomic version of the underlying type of [`Id`].
-/// This type should be used only in performance-critical sections
-/// and is not as general replacement for [`Id`].
-#[derive(Default)]
-#[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde-1", serde(transparent))]
-pub(crate) struct AtomicId(AtomicU32);
-
-impl From<usize> for AtomicId {
-    fn from(n: usize) -> AtomicId {
-        AtomicId(AtomicU32::new(n as u32))
-    }
-}
-
-impl From<AtomicId> for usize {
-    fn from(id: AtomicId) -> usize {
-        id.0.load(Ordering::SeqCst) as usize
-    }
-}
-
-impl AtomicId {
-    /// Retrieves the value from this [`AtomicId`] using [`Ordering::Relaxed`].
-    pub fn load_relaxed(&self) -> Id {
-        Id(self.0.load(Ordering::Relaxed))
-    }
-
-    /// Stores a value in this [`AtomicId`] using [`Ordering::Relaxed`].
-    pub fn store_relaxed(&self, new_value: Id) {
-        self.0.store(new_value.0, Ordering::Relaxed);
-    }
-}
-
-impl Clone for AtomicId {
-    fn clone(&self) -> Self {
-        Self(AtomicU32::from(self.0.load(Ordering::SeqCst)))
-    }
-}
-
-impl From<u32> for AtomicId {
-    fn from(n: u32) -> AtomicId {
-        AtomicId(AtomicU32::new(n))
-    }
-}
-
-impl std::fmt::Debug for AtomicId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0.load(Ordering::SeqCst))
-    }
-}
-
-impl std::fmt::Display for AtomicId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0.load(Ordering::SeqCst))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,12 +105,20 @@ pub use {
     util::*,
 };
 
+/// Trait implemented automatically either for all types
+/// (when the `parallel-matching` option is not set),
+/// or all types implementing `Send + Sync`
+/// (when the `parallel-matching` option is set).
 #[cfg(feature = "parallel-matching")]
-pub(crate) trait MaybePar: Send + Sync {}
+pub trait MaybePar: Send + Sync {}
 
 #[cfg(feature = "parallel-matching")]
 impl<T> MaybePar for T where T: Send + Sync {}
 
+/// Trait implemented automatically either for all types
+/// (when the `parallel-matching` option is not set),
+/// or all types implementing `Send + Sync`
+/// (when the `parallel-matching` option is set).
 #[cfg(not(feature = "parallel-matching"))]
 pub trait MaybePar {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ for less or more logging.
 #![doc = include_str!("../tests/simple.rs")]
 #![doc = "\n```"]
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
 mod macros;
 
 #[doc(hidden)]
@@ -82,6 +84,63 @@ impl std::fmt::Debug for Id {
 impl std::fmt::Display for Id {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// A key to identify [`EClass`]es which can be used in parallel algorithms.
+/// Its underlying type should be the atomic version of the underlying type of [`Id`].
+/// This type should be used only in performance-critical sections
+/// and is not as general replacement for [`Id`].
+#[derive(Default)]
+#[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-1", serde(transparent))]
+pub(crate) struct AtomicId(AtomicU32);
+
+impl From<usize> for AtomicId {
+    fn from(n: usize) -> AtomicId {
+        AtomicId(AtomicU32::new(n as u32))
+    }
+}
+
+impl From<AtomicId> for usize {
+    fn from(id: AtomicId) -> usize {
+        id.0.load(Ordering::SeqCst) as usize
+    }
+}
+
+impl AtomicId {
+    /// Retrieves the value from this [`AtomicId`] using [`Ordering::Relaxed`].
+    pub fn load_relaxed(&self) -> Id {
+        Id(self.0.load(Ordering::Relaxed))
+    }
+
+    /// Stores a value in this [`AtomicId`] using [`Ordering::Relaxed`].
+    pub fn store_relaxed(&self, new_value: Id) {
+        self.0.store(new_value.0, Ordering::Relaxed);
+    }
+}
+
+impl Clone for AtomicId {
+    fn clone(&self) -> Self {
+        Self(AtomicU32::from(self.0.load(Ordering::SeqCst)))
+    }
+}
+
+impl From<u32> for AtomicId {
+    fn from(n: u32) -> AtomicId {
+        AtomicId(AtomicU32::new(n))
+    }
+}
+
+impl std::fmt::Debug for AtomicId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.load(Ordering::SeqCst))
+    }
+}
+
+impl std::fmt::Display for AtomicId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.load(Ordering::SeqCst))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,18 @@ pub use {
     util::*,
 };
 
+#[cfg(feature = "parallel-matching")]
+pub(crate) trait MaybePar: Send + Sync {}
+
+#[cfg(feature = "parallel-matching")]
+impl<T> MaybePar for T where T: Send + Sync {}
+
+#[cfg(not(feature = "parallel-matching"))]
+pub trait MaybePar {}
+
+#[cfg(not(feature = "parallel-matching"))]
+impl<T> MaybePar for T {}
+
 #[cfg(feature = "lp")]
 pub use lp_extract::*;
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -313,7 +313,6 @@ impl<L: Language, A: Analysis<L>> Searcher<L, A> for Pattern<L> {
 
     #[cfg(feature = "parallel-matching")]
     fn par_search_with_limit(&self, egraph: &EGraph<L, A>, limit: usize) -> Vec<SearchMatches<L>> {
-        println!("In par_search_with_limit");
         match self.ast.as_ref().last().unwrap() {
             ENodeOrVar::ENode(e) => {
                 let key = e.discriminant();

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -89,7 +89,7 @@ impl<L: Language, N: Analysis<L>> Rewrite<L, N> {
     pub fn search(&self, egraph: &EGraph<L, N>) -> Vec<SearchMatches<L>> {
         self.searcher.search(egraph)
     }
-    
+
     /// Call [`par_search`] on the [`Searcher`].
     ///
     /// [`par_search`]: Searcher::par_search()
@@ -269,8 +269,7 @@ where
     ///
     /// [`search_with_limit`]: Searcher::search_with_limit
     #[cfg(feature = "parallel-matching")]
-    fn par_search_with_limit(&self, egraph: &EGraph<L, N>, limit: usize) -> Vec<SearchMatches<L>>
-    {
+    fn par_search_with_limit(&self, egraph: &EGraph<L, N>, limit: usize) -> Vec<SearchMatches<L>> {
         par_search_eclasses_with_limit(self, egraph, egraph.par_classes().map(|e| e.id), limit)
     }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -62,7 +62,7 @@ impl<L: Language, N: Analysis<L>> Rewrite<L, N> {
     ///
     pub fn new(
         name: impl Into<Symbol>,
-        searcher: impl Searcher<L, N> + Send + 'static,
+        searcher: impl Searcher<L, N> + Send + Sync + 'static,
         applier: impl Applier<L, N> + Send + Sync + 'static,
     ) -> Result<Self, String> {
         let name = name.into();
@@ -217,7 +217,7 @@ where
 /// matching substitutions.
 /// Right now the only significant [`Searcher`] is [`Pattern`].
 ///
-pub trait Searcher<L, N>: Sync
+pub trait Searcher<L, N>: MaybePar
 where
     L: Language,
     N: Analysis<L>,

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -62,7 +62,7 @@ impl<L: Language, N: Analysis<L>> Rewrite<L, N> {
     ///
     pub fn new(
         name: impl Into<Symbol>,
-        searcher: impl Searcher<L, N> + Send + Sync + 'static,
+        searcher: impl Searcher<L, N> + Send + 'static,
         applier: impl Applier<L, N> + Send + Sync + 'static,
     ) -> Result<Self, String> {
         let name = name.into();

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -185,7 +185,7 @@ where
     let limit = AtomicUsize::new(limit);
     eclasses
         .into_par_iter()
-        .map(|eclass| {
+        .flat_map(|eclass| {
             let mut limit_loaded = limit.load(ATOMIC_ORDERING);
             if limit_loaded == 0 {
                 return None;
@@ -208,7 +208,6 @@ where
                 }
             }
         })
-        .flatten()
         .collect()
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -747,12 +747,11 @@ where
     }
 
     /// Like [`search_rewrite`](RewriteScheduler::search_rewrite),
-    /// but takes `&self` instead of `&mut self`,
-    /// allowing this function to be used in parallel matching.
-    /// If modification is necessary,
+    /// but calls [`par_search`](Rewrite::par_search),
+    /// instead of [`search`](Rewrite::search).
+    /// It also acts on `&self` instead of `&mut self`,
+    /// so if modification is necessary,
     /// interior mutability has to be used (e.g. [`Arc`](std::sync::Arc)).
-    ///
-    /// Default implementation panics.
     #[cfg(feature = "parallel-matching")]
     fn par_search_rewrite<'a>(
         &self,

--- a/src/run.rs
+++ b/src/run.rs
@@ -728,7 +728,7 @@ the [`EGraph`] and dominating how much time is spent while running the
 
 */
 #[allow(unused_variables)]
-pub trait RewriteScheduler<L, N>: Sync
+pub trait RewriteScheduler<L, N>: MaybePar
 where
     L: Language,
     N: Analysis<L>,

--- a/src/run.rs
+++ b/src/run.rs
@@ -7,6 +7,8 @@ use log::*;
 
 use crate::*;
 
+/// Trait which has to be implemented for all hooks used in `Runner`.
+/// It should be implemented automatically.
 pub trait RunnerHook<L, N, I>:
     FnMut(&mut Runner<L, N, I>) -> Result<(), String> + MaybePar
 {

--- a/src/run.rs
+++ b/src/run.rs
@@ -645,7 +645,7 @@ where
         let matches_result = rules
             .par_iter()
             .map(|rw| {
-                let ms = self.scheduler.search_rewrite_const(iter, &self.egraph, rw);
+                let ms = self.scheduler.par_search_rewrite(iter, &self.egraph, rw);
                 self.check_limits().map(|_| ms)
             })
             .collect();
@@ -662,9 +662,9 @@ where
     #[cfg(not(feature = "parallel-matching"))]
     fn par_find_matches<'a, 'b: 'a>(
         &self,
-        rules: &[&'b Rewrite<L, N>],
-        matches: &'a mut Vec<Vec<SearchMatches<'b, L>>>,
-        iter: usize,
+        _rules: &[&'b Rewrite<L, N>],
+        _matches: &'a mut Vec<Vec<SearchMatches<'b, L>>>,
+        _iter: usize,
     ) -> RunnerResult<()> {
         panic!("Parallel matching must be enabled with 'parallel-matching' compilation flag")
     }
@@ -753,13 +753,14 @@ where
     /// interior mutability has to be used (e.g. [`Arc`](std::sync::Arc)).
     ///
     /// Default implementation panics.
-    fn search_rewrite_const<'a>(
+    #[cfg(feature = "parallel-matching")]
+    fn par_search_rewrite<'a>(
         &self,
         iteration: usize,
         egraph: &EGraph<L, N>,
         rewrite: &'a Rewrite<L, N>,
     ) -> Vec<SearchMatches<'a, L>> {
-        panic!("Constant searching not implemented.")
+        rewrite.par_search(egraph)
     }
 
     /// A hook allowing you to customize rewrite application behavior.

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,50 +1,66 @@
-use crate::Id;
+use crate::{AtomicId, Id};
+
 use std::fmt::Debug;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnionFind {
-    parents: Vec<Id>,
+    // Because the correctness of the structure does not depend on exact shape of the tree but only
+    // on the fact whether the root is correct, relaxed atomic operations can be used.
+    // They may race not produce the same structure as a sequential algorithm, but the structure
+    // is going to be correct nonetheless, at minimal synchronization cost.
+    parents: Vec<AtomicId>,
 }
 
 impl UnionFind {
     pub fn make_set(&mut self) -> Id {
-        let id = Id::from(self.parents.len());
-        self.parents.push(id);
-        id
+        let idx = self.parents.len();
+        self.parents.push(AtomicId::from(idx));
+        Id::from(idx)
     }
 
     pub fn size(&self) -> usize {
         self.parents.len()
     }
 
-    fn parent(&self, query: Id) -> Id {
-        self.parents[usize::from(query)]
+    fn parent(&self, query: Id) -> &AtomicId {
+        &self.parents[usize::from(query)]
     }
 
-    fn parent_mut(&mut self, query: Id) -> &mut Id {
+    fn parent_mut(&mut self, query: Id) -> &mut AtomicId {
         &mut self.parents[usize::from(query)]
     }
 
-    pub fn find(&self, mut current: Id) -> Id {
-        while current != self.parent(current) {
-            current = self.parent(current)
-        }
-        current
+    fn parent_relaxed(&self, query: Id) -> Id {
+        self.parent(query).load_relaxed()
     }
 
-    pub fn find_mut(&mut self, mut current: Id) -> Id {
-        while current != self.parent(current) {
-            let grandparent = self.parent(self.parent(current));
-            *self.parent_mut(current) = grandparent;
+    fn set_parent_mut(&mut self, query: Id, new_parent: Id) {
+        *self.parent_mut(query).0.get_mut() = new_parent.0;
+    }
+
+    fn set_parent_relaxed(&self, query: Id, new_parent: Id) {
+        self.parents[usize::from(query)].store_relaxed(new_parent);
+    }
+
+    pub fn find(&self, mut current: Id) -> Id {
+        // Because another thread might be running the same function, `parent` and `grandparent`
+        // might not refer to actual parent and grandparent after assignment.
+        // However, they are guaranteed to point to some ancestor, which is enough for this
+        // function to keep the invariants of the unionfind.
+        let mut parent = self.parent_relaxed(current);
+        while current != parent {
+            let grandparent = self.parent_relaxed(parent);
+            self.set_parent_relaxed(current, grandparent);
             current = grandparent;
+            parent = self.parent_relaxed(current);
         }
         current
     }
 
     /// Given two leader ids, unions the two eclasses making root1 the leader.
     pub fn union(&mut self, root1: Id, root2: Id) -> Id {
-        *self.parent_mut(root2) = root1;
+        self.set_parent_mut(root2, root1);
         root1
     }
 }
@@ -53,7 +69,7 @@ impl UnionFind {
 mod tests {
     use super::*;
 
-    fn ids(us: impl IntoIterator<Item = usize>) -> Vec<Id> {
+    fn ids(us: impl IntoIterator<Item = usize>) -> Vec<AtomicId> {
         us.into_iter().map(|u| u.into()).collect()
     }
 
@@ -68,7 +84,10 @@ mod tests {
         }
 
         // test the initial condition of everyone in their own set
-        assert_eq!(uf.parents, ids(0..n));
+        assert!(ids(0..n)
+            .into_iter()
+            .zip(uf.parents.iter())
+            .all(|(a, b)| a.load_relaxed() == b.load_relaxed()));
 
         // build up one set
         uf.union(id(0), id(1));
@@ -82,11 +101,14 @@ mod tests {
 
         // this should compress all paths
         for i in 0..n {
-            uf.find_mut(id(i));
+            uf.find(id(i));
         }
 
         // indexes:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9
         let expected = vec![0, 0, 0, 0, 4, 5, 6, 6, 6, 6];
-        assert_eq!(uf.parents, ids(expected));
+        assert!(ids(expected)
+            .into_iter()
+            .zip(uf.parents.iter())
+            .all(|(a, b)| a.load_relaxed() == b.load_relaxed()));
     }
 }

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,66 +1,50 @@
-use crate::{AtomicId, Id};
-
+use crate::Id;
 use std::fmt::Debug;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnionFind {
-    // Because the correctness of the structure does not depend on exact shape of the tree but only
-    // on the fact whether the root is correct, relaxed atomic operations can be used.
-    // They may race not produce the same structure as a sequential algorithm, but the structure
-    // is going to be correct nonetheless, at minimal synchronization cost.
-    parents: Vec<AtomicId>,
+    parents: Vec<Id>,
 }
 
 impl UnionFind {
     pub fn make_set(&mut self) -> Id {
-        let idx = self.parents.len();
-        self.parents.push(AtomicId::from(idx));
-        Id::from(idx)
+        let id = Id::from(self.parents.len());
+        self.parents.push(id);
+        id
     }
 
     pub fn size(&self) -> usize {
         self.parents.len()
     }
 
-    fn parent(&self, query: Id) -> &AtomicId {
-        &self.parents[usize::from(query)]
+    fn parent(&self, query: Id) -> Id {
+        self.parents[usize::from(query)]
     }
 
-    fn parent_mut(&mut self, query: Id) -> &mut AtomicId {
+    fn parent_mut(&mut self, query: Id) -> &mut Id {
         &mut self.parents[usize::from(query)]
     }
 
-    fn parent_relaxed(&self, query: Id) -> Id {
-        self.parent(query).load_relaxed()
-    }
-
-    fn set_parent_mut(&mut self, query: Id, new_parent: Id) {
-        *self.parent_mut(query).0.get_mut() = new_parent.0;
-    }
-
-    fn set_parent_relaxed(&self, query: Id, new_parent: Id) {
-        self.parents[usize::from(query)].store_relaxed(new_parent);
-    }
-
     pub fn find(&self, mut current: Id) -> Id {
-        // Because another thread might be running the same function, `parent` and `grandparent`
-        // might not refer to actual parent and grandparent after assignment.
-        // However, they are guaranteed to point to some ancestor, which is enough for this
-        // function to keep the invariants of the unionfind.
-        let mut parent = self.parent_relaxed(current);
-        while current != parent {
-            let grandparent = self.parent_relaxed(parent);
-            self.set_parent_relaxed(current, grandparent);
+        while current != self.parent(current) {
+            current = self.parent(current)
+        }
+        current
+    }
+
+    pub fn find_mut(&mut self, mut current: Id) -> Id {
+        while current != self.parent(current) {
+            let grandparent = self.parent(self.parent(current));
+            *self.parent_mut(current) = grandparent;
             current = grandparent;
-            parent = self.parent_relaxed(current);
         }
         current
     }
 
     /// Given two leader ids, unions the two eclasses making root1 the leader.
     pub fn union(&mut self, root1: Id, root2: Id) -> Id {
-        self.set_parent_mut(root2, root1);
+        *self.parent_mut(root2) = root1;
         root1
     }
 }
@@ -69,7 +53,7 @@ impl UnionFind {
 mod tests {
     use super::*;
 
-    fn ids(us: impl IntoIterator<Item = usize>) -> Vec<AtomicId> {
+    fn ids(us: impl IntoIterator<Item = usize>) -> Vec<Id> {
         us.into_iter().map(|u| u.into()).collect()
     }
 
@@ -84,10 +68,7 @@ mod tests {
         }
 
         // test the initial condition of everyone in their own set
-        assert!(ids(0..n)
-            .into_iter()
-            .zip(uf.parents.iter())
-            .all(|(a, b)| a.load_relaxed() == b.load_relaxed()));
+        assert_eq!(uf.parents, ids(0..n));
 
         // build up one set
         uf.union(id(0), id(1));
@@ -101,14 +82,11 @@ mod tests {
 
         // this should compress all paths
         for i in 0..n {
-            uf.find(id(i));
+            uf.find_mut(id(i));
         }
 
         // indexes:         0, 1, 2, 3, 4, 5, 6, 7, 8, 9
         let expected = vec![0, 0, 0, 0, 4, 5, 6, 6, 6, 6];
-        assert!(ids(expected)
-            .into_iter()
-            .zip(uf.parents.iter())
-            .all(|(a, b)| a.load_relaxed() == b.load_relaxed()));
+        assert_eq!(uf.parents, ids(expected));
     }
 }


### PR DESCRIPTION
This PR adds a parallel matching algorithm using relaxed memory ordering atomic operations in the `UnionFind`, allowing for parallel path compression. Theoretically, this is overhead-free on x86 (because of total store order), other than some cache coherence magic. Some people may remember it from conversations at PLDI 2024. This makes parallel matching scale well with the number of threads.

The functionality is hidden behind `parallel-matching` feature. When the feature is activated, you can set `parallel_matching` to `true` in `Runner` to use it.

Atomics in the `UnionFind` are always used, regardless of the `parallel-matching` feature. There could be two implementations, the new one and the old one, depending on `parallel-matching`, although in my opinion it would add unnecessary maintenance overhead. Opinions on this topic are welcome.