### PR TITLE
Refactor existance proofs, fixing bugs in the process

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -857,7 +857,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     /// Like `add_expr_uncanonical` but with an existence reason.
-    /// When the `reason` is `None`, this method panics when the added expression
+    /// When the `reason` is [`ExistenceReason::ExpectExists`], this method panics when the added expression
     /// is not already represented by the egraph.
     fn add_expr_uncanonical_with_reason(
         &mut self,
@@ -907,7 +907,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     /// Calling [`id_to_expr`](EGraph::id_to_expr) on this `Id` return an correspond to the
     /// instantiation of the pattern.
     ///
-    /// When `existence` is `None`, this method panics when the instantiated pattern
+    /// When `existence` is [`ExistenceReason::ExpectExists`], this method panics when the instantiated pattern
     /// is not by congruence to another term.
     pub(crate) fn add_instantiation_noncanonical(
         &mut self,

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -852,7 +852,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     ///
     /// Calling [`id_to_expr`](EGraph::id_to_expr) on this `Id` return a copy of `expr` when explanations are enabled
     pub fn add_expr_uncanonical(&mut self, expr: &RecExpr<L>) -> Id {
-        eprintln!("Adding {:?} directly", expr);
         self.add_expr_uncanonical_with_reason(expr, ExistsOrReason::Reason(ExistenceReason::Direct))
     }
 
@@ -1221,27 +1220,6 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         let id1 =
             self.add_instantiation_noncanonical(from_pat, subst, Some(ExistenceReason::Direct));
         // add the rhs, with reason equal to lhs
-        let id2 =
-            self.add_instantiation_noncanonical(to_pat, subst, Some(ExistenceReason::EqualTo(id1)));
-
-        let did_union = self.perform_union(id1, id2, Some(Justification::Rule(rule_name.into())));
-        (self.find(id1), did_union)
-    }
-
-    /// Like `union_instantiations`, but assumes that the `from_pat` and substitution
-    /// is guaranteed to match the egraph already.
-    /// Using this method makes existence explanations more precise.
-    pub fn union_instantiations_guaranteed_match(
-        &mut self,
-        from_pat: &PatternAst<L>,
-        to_pat: &PatternAst<L>,
-        subst: &Subst,
-        rule_name: impl Into<Symbol>,
-    ) -> (Id, bool) {
-        // add the lhs without an existence reason,
-        // assuming it matches
-        let id1 = self.add_instantiation_noncanonical(from_pat, subst, None);
-        // add the rhs, making it equal to the lhs
         let id2 =
             self.add_instantiation_noncanonical(to_pat, subst, Some(ExistenceReason::EqualTo(id1)));
 

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -900,7 +900,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         for node in nodes {
             match node {
                 ENodeOrVar::Var(var) => {
-                    let id = self.find(subst[*var]);
+                    let id = subst[*var];
                     new_ids.push(id);
                     new_node_q.push(false);
                 }
@@ -1077,7 +1077,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     ) -> Id {
         let original = enode.clone();
         if let Some(existing_id) = self.lookup_internal(&mut enode) {
-            let id = self.find(existing_id);
+            let leader = self.find(existing_id);
             // when explanations are enabled, we need a new representative for this expr
             if let Some(explain) = self.explain.as_mut() {
                 if let Some(existing_explain) = explain.uncanon_memo.get(&original) {
@@ -1088,13 +1088,13 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                     explain.add(
                         original.clone(),
                         new_id,
-                        existance.unwrap_or(ExistanceReason::EqualTo(id)),
+                        existance.unwrap_or(ExistanceReason::EqualTo(existing_id)),
                     );
                     debug_assert_eq!(Id::from(self.nodes.len()), new_id);
                     self.nodes.push(original);
                     // careful to make the old id the leader!
                     // otherwise, the hash-cons may become out-of-date while adding `lhs_terms`
-                    self.unionfind.union(id, new_id);
+                    self.unionfind.union(leader, new_id);
                     explain.union(existing_id, new_id, Justification::Congruence);
                     new_id
                 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1144,6 +1144,9 @@ impl<'x, L: Language> ExplainNodes<'x, L> {
                             &next_explanation,
                             rule,
                         ) {
+                            eprintln!("{:?}", current_explanation);
+                            eprintln!("{:?}", rule.name);
+                            eprintln!("{:?}", next_explanation);
                             return false;
                         }
                     }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1325,7 +1325,7 @@ impl<'x, L: Language> ExplainNodes<'x, L> {
                 let adj = self.explain_adjacent(connection, cache, enode_cache, false);
                 let mut exp = self.explain_term_existance(adjacent_id, adj, cache, enode_cache);
                 exp.push(rest_of_proof);
-                return exp;
+                exp
             }
             ExistanceReason::Direct => {
                 vec![self.node_to_explanation(term, enode_cache), rest_of_proof]

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -423,6 +423,7 @@ impl<L: Language> Explanation<L> {
             assert!(has_forward ^ has_backward);
 
             if has_forward {
+                eprintln!("Checking rewrite forward from {:?} to {:?}", current, next);
                 assert!(self.check_rewrite_at(current, next, &rule_table, true));
             } else {
                 assert!(self.check_rewrite_at(current, next, &rule_table, false));
@@ -1326,22 +1327,19 @@ impl<'x, L: Language> ExplainNodes<'x, L> {
             }
             ExistenceReason::EqualTo(adjacent_id) => {
                 let adjacent_node = &self.explainfind[usize::from(adjacent_id)];
-                // The node should be directly adjacent to another node
                 let connection = if node.parent_connection.next == adjacent_id {
                     let mut connection = node.parent_connection.clone();
                     connection.is_rewrite_forward = !connection.is_rewrite_forward;
                     std::mem::swap(&mut connection.next, &mut connection.current);
                     connection
                 } else {
-                    assert!(
-                        adjacent_node.parent_connection.next == term,
-                        "existence reason between two nodes failed: not directly adjacent."
-                    );
+                    assert_eq!(node.parent_connection.next, adjacent_id);
                     adjacent_node.parent_connection.clone()
                 };
 
                 let adj = self.explain_adjacent(connection, cache, enode_cache, false);
                 let mut exp = self.explain_term_existence(adjacent_id, adj, cache, enode_cache);
+
                 exp.push(rest_of_proof);
                 exp
             }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1144,9 +1144,6 @@ impl<'x, L: Language> ExplainNodes<'x, L> {
                             &next_explanation,
                             rule,
                         ) {
-                            eprintln!("{:?}", current_explanation);
-                            eprintln!("{:?}", rule.name);
-                            eprintln!("{:?}", next_explanation);
                             return false;
                         }
                     }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -54,6 +54,10 @@ pub(crate) enum ExistenceReason {
     Unset,
 }
 
+/// When explaining the existence of a term,
+/// this enum is used to specify whether the term is
+/// 1) Expected to already be represented by the egraph (is equal to some other term via congruence)
+/// or 2) Should be inserted with a particular reason
 pub enum ExistsOrReason {
     ExpectExists,
     Reason(ExistenceReason),

--- a/src/multipattern.rs
+++ b/src/multipattern.rs
@@ -124,6 +124,7 @@ impl<L: Language, A: Analysis<L>> Searcher<L, A> for MultiPattern<L> {
         } else {
             Some(SearchMatches {
                 eclass,
+                lhs_terms: None,
                 substs,
                 ast: None,
             })

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -386,10 +386,6 @@ where
         _searcher_ast: Option<&PatternAst<L>>,
         rule_name: Symbol,
     ) -> Vec<Id> {
-        let ast = self.ast.as_ref();
-        let mut id_buf = vec![0.into(); ast.len()];
-        let id = apply_pat(&mut id_buf, ast, egraph, subst);
-
         if egraph.are_explanations_enabled() {
             let (from, did_something) =
                 egraph.union_matched_rule(lhs_term, &self.ast, subst, rule_name);
@@ -398,10 +394,15 @@ where
             } else {
                 vec![]
             }
-        } else if egraph.union(lhs_term, id) {
-            vec![lhs_term]
         } else {
-            vec![]
+            let ast = self.ast.as_ref();
+            let mut id_buf = vec![0.into(); ast.len()];
+            let id = apply_pat(&mut id_buf, ast, egraph, subst);
+            if egraph.union(lhs_term, id) {
+                vec![lhs_term]
+            } else {
+                vec![]
+            }
         }
     }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -356,8 +356,13 @@ where
                 let did_something;
                 let id;
                 if egraph.are_explanations_enabled() {
-                    let (id_temp, did_something_temp) =
-                        egraph.union_instantiations(sast.unwrap(), &self.ast, subst, rule_name);
+                    let (id_temp, did_something_temp) = egraph
+                        .union_instantiations_guaranteed_match(
+                            sast.unwrap(),
+                            &self.ast,
+                            subst,
+                            rule_name,
+                        );
                     did_something = did_something_temp;
                     id = id_temp;
                 } else {
@@ -387,7 +392,7 @@ where
 
         if let Some(ast) = searcher_ast {
             let (from, did_something) =
-                egraph.union_instantiations(ast, &self.ast, subst, rule_name);
+                egraph.union_instantiations_guaranteed_match(ast, &self.ast, subst, rule_name);
             if did_something {
                 vec![from]
             } else {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -341,7 +341,11 @@ where
         for mat in matches {
             if egraph.are_explanations_enabled() {
                 let sast = mat.ast.as_ref().map(|cow| cow.as_ref());
-                for (subst, lhs_term) in mat.substs.iter().zip(mat.lhs_terms.as_ref().unwrap().iter()) {
+                for (subst, lhs_term) in mat
+                    .substs
+                    .iter()
+                    .zip(mat.lhs_terms.as_ref().unwrap().iter())
+                {
                     let ids = self.apply_one(egraph, *lhs_term, subst, sast, rule_name);
                     added.extend(ids)
                 }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -338,16 +338,18 @@ where
     ) -> Vec<Id> {
         let mut added = vec![];
 
-        if egraph.are_explanations_enabled() {
-            let ast = mat.ast.as_ref().map(|cow| cow.as_ref());
-            for (subst, lhs_term) in mat.substs.iter().zip(mat.lhs_terms.unwrap().iter()) {
-                let ids = self.apply_one(egraph, mat.eclass, subst, None, rule_name);
-                added.extend(ids)
-            }
-        } else {
-            for subst in &mat.substs {
-                let ids = self.apply_one(egraph, mat.eclass, subst, None, rule_name);
-                added.extend(ids)
+        for mat in matches {
+            if egraph.are_explanations_enabled() {
+                let sast = mat.ast.as_ref().map(|cow| cow.as_ref());
+                for (subst, lhs_term) in mat.substs.iter().zip(mat.lhs_terms.as_ref().unwrap().iter()) {
+                    let ids = self.apply_one(egraph, *lhs_term, subst, sast, rule_name);
+                    added.extend(ids)
+                }
+            } else {
+                for subst in &mat.substs {
+                    let ids = self.apply_one(egraph, mat.eclass, subst, None, rule_name);
+                    added.extend(ids)
+                }
             }
         }
 
@@ -429,14 +431,14 @@ where
     fn apply_one(
         &self,
         egraph: &mut EGraph<L, N>,
-        eclass: Id,
+        lhs_term: Id,
         subst: &Subst,
         searcher_ast: Option<&PatternAst<L>>,
         rule_name: Symbol,
     ) -> Vec<Id> {
-        if self.condition.check(egraph, eclass, subst) {
+        if self.condition.check(egraph, lhs_term, subst) {
             self.applier
-                .apply_one(egraph, eclass, subst, searcher_ast, rule_name)
+                .apply_one(egraph, lhs_term, subst, searcher_ast, rule_name)
         } else {
             vec![]
         }

--- a/src/run.rs
+++ b/src/run.rs
@@ -462,18 +462,18 @@ where
         self.egraph.explain_equivalence(left, right)
     }
 
-    /// Calls [`EGraph::explain_existance`](EGraph::explain_existance()).
-    pub fn explain_existance(&mut self, expr: &RecExpr<L>) -> Explanation<L> {
-        self.egraph.explain_existance(expr)
+    /// Calls [`EGraph::explain_existence`](EGraph::explain_existence()).
+    pub fn explain_existence(&mut self, expr: &RecExpr<L>) -> Explanation<L> {
+        self.egraph.explain_existence(expr)
     }
 
-    /// Calls [EGraph::explain_existance_pattern`](EGraph::explain_existance_pattern()).
-    pub fn explain_existance_pattern(
+    /// Calls [EGraph::explain_existence_pattern`](EGraph::explain_existence_pattern()).
+    pub fn explain_existence_pattern(
         &mut self,
         pattern: &PatternAst<L>,
         subst: &Subst,
     ) -> Explanation<L> {
-        self.egraph.explain_existance_pattern(pattern, subst)
+        self.egraph.explain_existence_pattern(pattern, subst)
     }
 
     /// Get an explanation for why an expression matches a pattern.

--- a/src/run.rs
+++ b/src/run.rs
@@ -554,20 +554,16 @@ where
         // when proofs are enabled, first add all LHS of terms to the egraph
         if self.egraph.are_explanations_enabled() {
             result = result.and_then(|_| {
-                rules.iter().zip(&mut matches).try_for_each(|(rw, ms)| {
-                    assert_eq!(ms.lhs_terms, None);
-                    
+                matches.iter_mut().try_for_each(|ms| {
                     for rule_match in ms {
+                        let sast = rule_match.ast.as_ref().expect("Expected all rewrites to have an AST for the lhs when explanations are enabled");
+                        assert_eq!(rule_match.lhs_terms, None);
                         let mut new_terms = vec![];
                         for subst in &rule_match.substs {
-                            // get the pattern of the lhs of the rule
-                            let lhs_pattern = rw.searcher.get_pattern_ast().expect("Expected all rewrites to have an AST for the lhs when explanations are enabled");
-
                             // now instantiate the pattern with the substitution, getting the new term's id
-                            let lhs_term = self.egraph.add_instantiation_noncanonical(lhs_pattern, subst, None);
+                            let lhs_term = self.egraph.add_instantiation_noncanonical(sast, subst, None);
 
                             new_terms.push(lhs_term);
-
                         }
                         rule_match.lhs_terms = Some(new_terms);
                     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -553,8 +553,7 @@ where
 
         // when proofs are enabled, first add all LHS of terms to the egraph
         if self.egraph.are_explanations_enabled() {
-            result = result.and_then(|_| {
-                matches.iter_mut().try_for_each(|ms| {
+            matches.iter_mut().for_each(|ms| {
                     for rule_match in ms {
                         let sast = rule_match.ast.as_ref().expect("Expected all rewrites to have an AST for the lhs when explanations are enabled");
                         assert_eq!(rule_match.lhs_terms, None);
@@ -567,10 +566,7 @@ where
                         }
                         rule_match.lhs_terms = Some(new_terms);
                     }
-                    
-                    self.check_limits()
                 })
-            })
         }
 
         result = result.and_then(|_| {

--- a/src/test.rs
+++ b/src/test.rs
@@ -34,7 +34,7 @@ pub fn test_runner<L, A>(
     goals: &[Pattern<L>],
     check_fn: Option<fn(Runner<L, A, ()>)>,
     should_check: bool,
-    check_existance_explanations: bool,
+    check_existence_explanations: bool,
 ) where
     L: Language + Display + FromOp + 'static,
     A: Analysis<L> + Default,
@@ -108,19 +108,19 @@ pub fn test_runner<L, A>(
                 explained.check_proof(rules);
                 assert!(!explained.get_tree_size().is_zero());
 
-                // now check for existance of the goal
+                // now check for existence of the goal
                 // it should exist due to the start expression
-                if check_existance_explanations {
-                    let mut existance_proof = runner.explain_existance_pattern(&goal.ast, &subst);
-                    existance_proof.check_proof(rules);
-                    let first_term_in_existance_proof: RecExpr<L> =
-                        existance_proof.make_flat_explanation()[0].get_recexpr();
+                if check_existence_explanations {
+                    let mut existence_proof = runner.explain_existence_pattern(&goal.ast, &subst);
+                    existence_proof.check_proof(rules);
+                    let first_term_in_existence_proof: RecExpr<L> =
+                        existence_proof.make_flat_explanation()[0].get_recexpr();
                     if !has_initial_expression {
                         assert_eq!(
-                            first_term_in_existance_proof,
+                            first_term_in_existence_proof,
                             start,
-                            "Existance proof failed to find original term. Existance proof: {}",
-                            existance_proof.get_flat_string()
+                            "existence proof failed to find original term. existence proof: {}",
+                            existence_proof.get_flat_string()
                         );
                     }
                 }
@@ -274,7 +274,7 @@ macro_rules! test_fn {
         =>
         $($goal:literal),+ $(,)?
         $(@check $check_fn:expr,)?
-        $(@existance $check_existance_explanations:expr)?
+        $(@existence $check_existence_explanations:expr)?
     ) => {
 
     $(#[$meta])*
@@ -290,7 +290,7 @@ macro_rules! test_fn {
             &[$( $goal.parse().unwrap() ),+],
             None $(.or(Some($check_fn)))?,
             check,
-            true $(&& $check_existance_explanations)?,
+            true $(&& $check_existence_explanations)?,
         )
     }};
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -290,7 +290,7 @@ macro_rules! test_fn {
             &[$( $goal.parse().unwrap() ),+],
             None $(.or(Some($check_fn)))?,
             check,
-            true $(&& $check_existence_explanations)?,
+            false $(|| $check_existence_explanations)?,
         )
     }};
 }

--- a/src/tutorials/_03_explanations.rs
+++ b/src/tutorials/_03_explanations.rs
@@ -60,7 +60,7 @@ In fact, normally the rules `times-zero` and `cancel-denominator` are perfectly
   reasonable.
 However, in the presence of a division by zero, they lead to arbitrary unions in the egraph.
 So the true problem is the presense of the term `(/ 1 0)`.
-For these kinds of questions, `egg` provides the `explain_existance` function which can be used to get an explanation
+For these kinds of questions, `egg` provides the `explain_existence` function which can be used to get an explanation
   of why a term exists in the egraph in the first place.
 
 

--- a/tests/explanation-cycle-constant-fold.rs
+++ b/tests/explanation-cycle-constant-fold.rs
@@ -1,0 +1,111 @@
+use egg::{Symbol, *};
+use std::time::Duration;
+
+define_language! {
+    pub enum Math {
+        "+" = Add([Id; 2]),
+        "*" = Mul([Id; 2]),
+        "/" = Div([Id; 2]),
+        "^" = Pow([Id; 2]),
+        Const(u64),
+        Var(Symbol),
+    }
+}
+
+pub type EGraph = egg::EGraph<Math, ConstantFold>;
+pub type Rewrite = egg::Rewrite<Math, ConstantFold>;
+pub type Runner = egg::Runner<Math, ConstantFold, ()>;
+
+#[derive(Default)]
+pub struct ConstantFold;
+impl Analysis<Math> for ConstantFold {
+    type Data = Option<(i64, PatternAst<Math>)>;
+
+    fn make(egraph: &mut EGraph, enode: &Math) -> Self::Data {
+        let x = |i: &Id| egraph[*i].data.as_ref().map(|d| d.0);
+        Some(match enode {
+            Math::Const(c) => (*c as i64, format!("{}", c).parse().unwrap()),
+            Math::Add([a, b]) => (
+                x(a)? + x(b)?,
+                format!("(+ {} {})", x(a)?, x(b)?).parse().unwrap(),
+            ),
+            Math::Mul([a, b]) => (
+                x(a)? * x(b)?,
+                format!("(* {} {})", x(a)?, x(b)?).parse().unwrap(),
+            ),
+            _ => return None,
+        })
+    }
+
+    fn merge(&mut self, to: &mut Self::Data, from: Self::Data) -> DidMerge {
+        merge_option(to, from, |a, b| {
+            assert_eq!(a.0, b.0, "Merged non-equal constants");
+            DidMerge(false, false)
+        })
+    }
+
+    fn modify(egraph: &mut EGraph, id: Id) {
+        let data = egraph[id].data.clone();
+        if let Some((c, pat)) = data {
+            if egraph.are_explanations_enabled() {
+                egraph.union_instantiations(
+                    &pat,
+                    &format!("{}", c).parse().unwrap(),
+                    &Default::default(),
+                    "constant_fold".to_string(),
+                );
+            } else {
+                let added = egraph.add(Math::Const(c as u64));
+                egraph.union(id, added);
+            }
+            // to not prune, comment this out
+            egraph[id].nodes.retain(|n| n.is_leaf());
+
+            #[cfg(debug_assertions)]
+            egraph[id].assert_unique_leaves();
+        }
+    }
+}
+
+fn is_not_zero(var: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
+    let var = var.parse().unwrap();
+    move |egraph, _, subst| {
+        if let Some(n) = &egraph[subst[var]].data {
+            n.0 != 0
+        } else {
+            true
+        }
+    }
+}
+
+#[test]
+fn repro_cycle_existance() {
+    let mut rules = vec![
+        rewrite!("add_comm";  "(+ ?a ?b)"        => "(+ ?b ?a)"),
+        rewrite!("mul_comm";  "(* ?a ?b)"        => "(* ?b ?a)"),
+        rewrite!("mul_zero"; "(* ?a 0)" => "0"),
+        rewrite!("recip-mul-div"; "(* ?x (/ 1 ?x))" => "1" if is_not_zero("?x")),
+    ];
+    rules.extend(rewrite!("add_assoc"; "(+ ?a (+ ?b ?c))" <=> "(+ (+ ?a ?b) ?c)"));
+    rules.extend(rewrite!("mul_assoc"; "(* ?a (* ?b ?c))" <=> "(* (* ?a ?b) ?c)"));
+    rules.extend(rewrite!("add_zero"; "(+ ?a 0)" <=> "?a"));
+    rules.extend(rewrite!("mul_one";  "(* ?a 1)" <=> "?a"));
+    rules.extend(rewrite!("distribute"; "(* ?a (+ ?b ?c))" <=> "(+ (* ?a ?b) (* ?a ?c))"));
+    rules.extend(rewrite!("div_canon"; "(/ ?a ?b)" <=> "(* ?a (^ ?b -1))" if is_not_zero("?b")));
+
+    let start = "(+ (/ a b) c)".parse().unwrap();
+    let end: RecExpr<Math> = "(/ (+ a (* b c)) b)".parse().unwrap();
+    let mut runner = Runner::default()
+        .with_explanations_enabled()
+        .with_expr(&start)
+        .with_expr(&end)
+        .with_time_limit(Duration::from_secs(1000000000000))
+        .with_iter_limit(6)
+        .with_node_limit(usize::MAX)
+        .run(&rules);
+
+    println!(
+        "{}",
+        runner.explain_equivalence(&start, &end).get_flat_string()
+    );
+}

--- a/tests/explanation-cycle-constant-fold.rs
+++ b/tests/explanation-cycle-constant-fold.rs
@@ -21,7 +21,7 @@ fn is_not_zero(var: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
 }
 
 #[test]
-fn repro_cycle_existance() {
+fn repro_cycle_existence() {
     let mut rules = vec![
         rewrite!("add_comm";  "(+ ?a ?b)"        => "(+ ?b ?a)"),
         rewrite!("mul_comm";  "(* ?a ?b)"        => "(* ?b ?a)"),

--- a/tests/explanation-cycle-constant-fold.rs
+++ b/tests/explanation-cycle-constant-fold.rs
@@ -17,9 +17,7 @@ pub type Rewrite = egg::Rewrite<Math, ()>;
 pub type Runner = egg::Runner<Math, (), ()>;
 
 fn is_not_zero(var: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
-    |egraph, _, subst| {
-        true
-    }
+    |egraph, _, subst| true
 }
 
 #[test]

--- a/tests/explanation_cycle_tutorial.rs
+++ b/tests/explanation_cycle_tutorial.rs
@@ -1,0 +1,24 @@
+use egg::{rewrite as rw, *};
+
+#[test]
+fn repro_tutorial_cycle() {
+    let rules: &[Rewrite<SymbolLang, ()>] = &[
+        rw!("div-one"; "?x" => "(/ ?x 1)"),
+        rw!("unsafe-invert-division"; "(/ ?a ?b)" => "(/ 1 (/ ?b ?a))"),
+        rw!("simplify-frac"; "(/ ?a (/ ?b ?c))" => "(/ (* ?a ?c) (* (/ ?b ?c) ?c))"),
+        rw!("cancel-denominator"; "(* (/ ?a ?b) ?b)" => "?a"),
+        rw!("times-zero"; "(* ?a 0)" => "0"),
+    ];
+
+    let start = "(/ (* (/ 2 3) (/ 3 2)) 1)".parse().unwrap();
+    let end = "1".parse().unwrap();
+    let mut runner = Runner::default()
+        .with_explanations_enabled()
+        .with_expr(&start)
+        .run(rules);
+
+    println!(
+        "{}",
+        runner.explain_equivalence(&start, &end).get_flat_string()
+    );
+}

--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -175,7 +175,7 @@ impl Applier<Lambda, LambdaAnalysis> for CaptureAvoid {
     fn apply_one(
         &self,
         egraph: &mut EGraph,
-        eclass: Id,
+        term: Id,
         subst: &Subst,
         searcher_ast: Option<&PatternAst<Lambda>>,
         rule_name: Symbol,
@@ -185,13 +185,13 @@ impl Applier<Lambda, LambdaAnalysis> for CaptureAvoid {
         let v2_free_in_e = egraph[e].data.free.contains(&v2);
         if v2_free_in_e {
             let mut subst = subst.clone();
-            let sym = Lambda::Symbol(format!("_{}", eclass).into());
+            let sym = Lambda::Symbol(format!("_{}", term).into());
             subst.insert(self.fresh, egraph.add(sym));
             self.if_free
-                .apply_one(egraph, eclass, &subst, searcher_ast, rule_name)
+                .apply_one(egraph, term, &subst, searcher_ast, rule_name)
         } else {
             self.if_not_free
-                .apply_one(egraph, eclass, subst, searcher_ast, rule_name)
+                .apply_one(egraph, term, subst, searcher_ast, rule_name)
         }
     }
 }
@@ -205,6 +205,7 @@ egg::test_fn! {
     // "(lam x (+ 4 (let y 4 (var y))))",
     // "(lam x (+ 4 4))",
     "(lam x 8))",
+    @existance false
 }
 
 egg::test_fn! {
@@ -214,6 +215,7 @@ egg::test_fn! {
          (+ (var a) (var b)))"
     =>
     "(+ (var a) (var b))"
+    @existance false
 }
 
 egg::test_fn! {
@@ -226,18 +228,21 @@ egg::test_fn! {
     //  (+ (var ?a) 1))",
     // "(+ 0 1)",
     "1",
+    @existance false
 }
 
 egg::test_fn! {
     #[should_panic(expected = "Could not prove goal 0")]
     lambda_capture, rules(),
     "(let x 1 (lam x (var x)))" => "(lam x 1)"
+    @existance false
 }
 
 egg::test_fn! {
     #[should_panic(expected = "Could not prove goal 0")]
     lambda_capture_free, rules(),
     "(let y (+ (var x) (var x)) (lam x (var y)))" => "(lam x (+ (var x) (var x)))"
+    @existance false
 }
 
 egg::test_fn! {
@@ -249,6 +254,7 @@ egg::test_fn! {
      (app (var add-five) 1))))"
     =>
     "7"
+    @existance false
 }
 
 egg::test_fn! {
@@ -262,11 +268,13 @@ egg::test_fn! {
                 (app (lam ?y (+ 1 (var ?y)))
                      (var ?x))))",
     "(lam ?x (+ (var ?x) 2))"
+    @existance false
 }
 
 egg::test_fn! {
     lambda_if_simple, rules(),
     "(if (= 1 1) 7 9)" => "7"
+    @existance false
 }
 
 egg::test_fn! {
@@ -283,6 +291,7 @@ egg::test_fn! {
                                    (var add1)))))))))"
     =>
     "(lam ?x (+ (var ?x) 7))"
+    @existance false
 }
 
 egg::test_fn! {
@@ -308,6 +317,7 @@ egg::test_fn! {
           2))))"
     =>
     "(lam ?x (+ (var ?x) 2))"
+    @existance false
 }
 
 egg::test_fn! {
@@ -322,6 +332,7 @@ egg::test_fn! {
     // "(+ (if false 0 1) (if true 0 1))",
     // "(+ 1 0)",
     "1",
+    @existance false
 }
 
 egg::test_fn! {
@@ -342,6 +353,7 @@ egg::test_fn! {
                 (+ (var n) -2)))))))
         (app (var fib) 4))"
     => "3"
+    @existance false
 }
 
 #[test]

--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -205,7 +205,7 @@ egg::test_fn! {
     // "(lam x (+ 4 (let y 4 (var y))))",
     // "(lam x (+ 4 4))",
     "(lam x 8))",
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -215,7 +215,7 @@ egg::test_fn! {
          (+ (var a) (var b)))"
     =>
     "(+ (var a) (var b))"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -228,21 +228,21 @@ egg::test_fn! {
     //  (+ (var ?a) 1))",
     // "(+ 0 1)",
     "1",
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
     #[should_panic(expected = "Could not prove goal 0")]
     lambda_capture, rules(),
     "(let x 1 (lam x (var x)))" => "(lam x 1)"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
     #[should_panic(expected = "Could not prove goal 0")]
     lambda_capture_free, rules(),
     "(let y (+ (var x) (var x)) (lam x (var y)))" => "(lam x (+ (var x) (var x)))"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -254,7 +254,7 @@ egg::test_fn! {
      (app (var add-five) 1))))"
     =>
     "7"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -268,13 +268,13 @@ egg::test_fn! {
                 (app (lam ?y (+ 1 (var ?y)))
                      (var ?x))))",
     "(lam ?x (+ (var ?x) 2))"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
     lambda_if_simple, rules(),
     "(if (= 1 1) 7 9)" => "7"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -291,7 +291,7 @@ egg::test_fn! {
                                    (var add1)))))))))"
     =>
     "(lam ?x (+ (var ?x) 7))"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -317,7 +317,7 @@ egg::test_fn! {
           2))))"
     =>
     "(lam ?x (+ (var ?x) 2))"
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -332,7 +332,7 @@ egg::test_fn! {
     // "(+ (if false 0 1) (if true 0 1))",
     // "(+ 1 0)",
     "1",
-    @existance false
+    @existence false
 }
 
 egg::test_fn! {
@@ -353,7 +353,7 @@ egg::test_fn! {
                 (+ (var n) -2)))))))
         (app (var fib) 4))"
     => "3"
-    @existance false
+    @existence false
 }
 
 #[test]

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -85,7 +85,7 @@ impl Analysis<Math> for ConstantFold {
         let data = egraph[id].data.clone();
         if let Some((c, pat)) = data {
             if egraph.are_explanations_enabled() {
-                egraph.union_instantiations(
+                egraph.union_instantiations_guaranteed_match(
                     &pat,
                     &format!("{}", c).parse().unwrap(),
                     &Default::default(),
@@ -221,7 +221,7 @@ egg::test_fn! {
     "(+ 1 (+ 2 (+ 3 (+ 4 (+ 5 (+ 6 7))))))"
     =>
     "(+ 7 (+ 6 (+ 5 (+ 4 (+ 3 (+ 2 1))))))"
-    @check |r: Runner<Math, ()>| assert_eq!(r.egraph.number_of_classes(), 127)
+    @check |r: Runner<Math, ()>| assert_eq!(r.egraph.number_of_classes(), 127),
 }
 
 egg::test_fn! {

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -85,7 +85,7 @@ impl Analysis<Math> for ConstantFold {
         let data = egraph[id].data.clone();
         if let Some((c, pat)) = data {
             if egraph.are_explanations_enabled() {
-                egraph.union_instantiations_guaranteed_match(
+                egraph.union_instantiations(
                     &pat,
                     &format!("{}", c).parse().unwrap(),
                     &Default::default(),
@@ -227,7 +227,8 @@ egg::test_fn! {
 egg::test_fn! {
     #[should_panic(expected = "Could not prove goal 0")]
     math_fail, rules(),
-    "(+ x y)" => "(/ x y)"
+    "(+ x y)" => "(/ x y)",
+    @existence false
 }
 
 egg::test_fn! {math_simplify_add, rules(), "(+ x (+ x (+ x x)))" => "(* 4 x)" }
@@ -235,7 +236,8 @@ egg::test_fn! {math_powers, rules(), "(* (pow 2 x) (pow 2 y))" => "(pow 2 (+ x y
 
 egg::test_fn! {
     math_simplify_const, rules(),
-    "(+ 1 (- a (* (- 2 1) a)))" => "1"
+    "(+ 1 (- a (* (- 2 1) a)))" => "1",
+    @existence false
 }
 
 egg::test_fn! {
@@ -249,6 +251,7 @@ egg::test_fn! {
              2)))"#
     =>
     "(/ 1 (sqrt five))"
+    @existence false
 }
 
 egg::test_fn! {
@@ -256,17 +259,19 @@ egg::test_fn! {
     "(* (+ x 3) (+ x 1))"
     =>
     "(+ (+ (* x x) (* 4 x)) 3)"
+    @existence false
 }
 
-egg::test_fn! {math_diff_same,      rules(), "(d x x)" => "1"}
+// Existence proofs don't support analysis, so we turn tests for them off
+egg::test_fn! {math_diff_same, rules(), "(d x x)" => "1"}
 egg::test_fn! {math_diff_different, rules(), "(d x y)" => "0"}
-egg::test_fn! {math_diff_simple1,   rules(), "(d x (+ 1 (* 2 x)))" => "2"}
 egg::test_fn! {math_diff_simple2,   rules(), "(d x (+ 1 (* y x)))" => "y"}
 egg::test_fn! {math_diff_ln,        rules(), "(d x (ln x))" => "(/ 1 x)"}
 
 egg::test_fn! {
     diff_power_simple, rules(),
-    "(d x (pow x 3))" => "(* 3 (pow x 2))"
+    "(d x (pow x 3))" => "(* 3 (pow x 2))",
+    @existence false
 }
 
 egg::test_fn! {
@@ -280,11 +285,13 @@ egg::test_fn! {
         .with_expr(&"(* x (- (* 3 x) 14))".parse().unwrap()),
     "(d x (- (pow x 3) (* 7 (pow x 2))))"
     =>
-    "(* x (- (* 3 x) 14))"
+    "(* x (- (* 3 x) 14))",
+    @existence false
 }
 
 egg::test_fn! {
-    integ_one, rules(), "(i 1 x)" => "x"
+    integ_one, rules(), "(i 1 x)" => "x",
+    @existence false
 }
 
 egg::test_fn! {

--- a/tests/math_no_analysis.rs
+++ b/tests/math_no_analysis.rs
@@ -1,0 +1,189 @@
+//! Since existence proofs don't support analysis,
+//! we test egg without analysis here.
+
+use egg::{rewrite as rw, *};
+use ordered_float::NotNan;
+
+pub type EGraph = egg::EGraph<Math, ()>;
+pub type Rewrite = egg::Rewrite<Math, ()>;
+
+pub type Constant = NotNan<f64>;
+
+define_language! {
+    pub enum Math {
+        "d" = Diff([Id; 2]),
+        "i" = Integral([Id; 2]),
+
+        "+" = Add([Id; 2]),
+        "-" = Sub([Id; 2]),
+        "*" = Mul([Id; 2]),
+        "/" = Div([Id; 2]),
+        "pow" = Pow([Id; 2]),
+        "ln" = Ln(Id),
+        "sqrt" = Sqrt(Id),
+
+        "sin" = Sin(Id),
+        "cos" = Cos(Id),
+
+        Constant(Constant),
+        Symbol(Symbol),
+    }
+}
+
+// You could use egg::AstSize, but this is useful for debugging, since
+// it will really try to get rid of the Diff operator
+pub struct MathCostFn;
+impl egg::CostFunction<Math> for MathCostFn {
+    type Cost = usize;
+    fn cost<C>(&mut self, enode: &Math, mut costs: C) -> Self::Cost
+    where
+        C: FnMut(Id) -> Self::Cost,
+    {
+        let op_cost = match enode {
+            Math::Diff(..) => 100,
+            Math::Integral(..) => 100,
+            _ => 1,
+        };
+        enode.fold(op_cost, |sum, i| sum + costs(i))
+    }
+}
+
+#[rustfmt::skip]
+pub fn rules() -> Vec<Rewrite> { vec![
+  rw!("add-1-1"; "(+ 1 1)" => "2"),
+  rw!("add-0-r"; "(+ ?a 0)" => "?a"),
+  rw!("add-0-l"; "(+ 0 ?a)" => "?a"),
+  rw!("add-2-2"; "(+ 2 2)" => "4"),
+  rw!("add-3-1"; "(+ 3 1)" => "4"),
+  rw!("sub-0-r"; "(- ?a 0)" => "?a"),
+  rw!("sub-0-1"; "(- 0 1)" => "-1"),
+  rw!("sub-1-0"; "(- 1 0)" => "1"),
+  rw!("sub-1-1"; "(- 1 1)" => "0"),
+  rw!("add-2-neg1"; "(+ 2 -1)" => "1"),
+  rw!("comm-add";  "(+ ?a ?b)"        => "(+ ?b ?a)"),
+  rw!("comm-mul";  "(* ?a ?b)"        => "(* ?b ?a)"),
+  rw!("assoc-add"; "(+ ?a (+ ?b ?c))" => "(+ (+ ?a ?b) ?c)"),
+  rw!("assoc-mul"; "(* ?a (* ?b ?c))" => "(* (* ?a ?b) ?c)"),
+
+  rw!("sub-canon"; "(- ?a ?b)" => "(+ ?a (* -1 ?b))"),
+  rw!("div-canon"; "(/ ?a ?b)" => "(* ?a (pow ?b -1))"),
+  // rw!("canon-sub"; "(+ ?a (* -1 ?b))"   => "(- ?a ?b)"),
+  // rw!("canon-div"; "(* ?a (pow ?b -1))" => "(/ ?a ?b)" if is_not_zero("?b")),
+
+  rw!("zero-add"; "(+ ?a 0)" => "?a"),
+  rw!("zero-mul"; "(* ?a 0)" => "0"),
+  rw!("one-mul";  "(* ?a 1)" => "?a"),
+
+  rw!("add-zero"; "?a" => "(+ ?a 0)"),
+  rw!("mul-one";  "?a" => "(* ?a 1)"),
+
+  rw!("cancel-sub"; "(- ?a ?a)" => "0"),
+  rw!("cancel-div"; "(/ ?a ?a)" => "1"),
+
+  rw!("distribute"; "(* ?a (+ ?b ?c))"        => "(+ (* ?a ?b) (* ?a ?c))"),
+  rw!("factor"    ; "(+ (* ?a ?b) (* ?a ?c))" => "(* ?a (+ ?b ?c))"),
+
+  rw!("pow-mul"; "(* (pow ?a ?b) (pow ?a ?c))" => "(pow ?a (+ ?b ?c))"),
+  rw!("pow0"; "(pow ?x 0)" => "1"),
+  rw!("pow1"; "(pow ?x 1)" => "?x"),
+  rw!("pow2"; "(pow ?x 2)" => "(* ?x ?x)"),
+  rw!("pow-recip"; "(pow ?x -1)" => "(/ 1 ?x)"),
+  rw!("recip-mul-div"; "(* ?x (/ 1 ?x))" => "1"),
+
+  rw!("d-variable"; "(d ?x ?x)" => "1"),
+  rw!("d-constant"; "(d ?x ?c)" => "0"),
+
+  rw!("d-add"; "(d ?x (+ ?a ?b))" => "(+ (d ?x ?a) (d ?x ?b))"),
+  rw!("d-mul"; "(d ?x (* ?a ?b))" => "(+ (* ?a (d ?x ?b)) (* ?b (d ?x ?a)))"),
+
+  rw!("d-sin"; "(d ?x (sin ?x))" => "(cos ?x)"),
+  rw!("d-cos"; "(d ?x (cos ?x))" => "(* -1 (sin ?x))"),
+
+  rw!("d-ln"; "(d ?x (ln ?x))" => "(/ 1 ?x)"),
+
+  rw!("d-power";
+      "(d ?x (pow ?f ?g))" =>
+      "(* (pow ?f ?g)
+          (+ (* (d ?x ?f)
+                (/ ?g ?f))
+             (* (d ?x ?g)
+                (ln ?f))))"
+  ),
+
+  rw!("i-one"; "(i 1 ?x)" => "?x"),
+  rw!("i-power-const"; "(i (pow ?x ?c) ?x)" =>
+      "(/ (pow ?x (+ ?c 1)) (+ ?c 1))"),
+  rw!("i-cos"; "(i (cos ?x) ?x)" => "(sin ?x)"),
+  rw!("i-sin"; "(i (sin ?x) ?x)" => "(* -1 (cos ?x))"),
+  rw!("i-sum"; "(i (+ ?f ?g) ?x)" => "(+ (i ?f ?x) (i ?g ?x))"),
+  rw!("i-dif"; "(i (- ?f ?g) ?x)" => "(- (i ?f ?x) (i ?g ?x))"),
+  rw!("i-parts"; "(i (* ?a ?b) ?x)" =>
+      "(- (* ?a (i ?b ?x)) (i (* (d ?x ?a) (i ?b ?x)) ?x))"),
+]}
+
+egg::test_fn! {
+    existence_associate_adds, [
+        rw!("comm-add"; "(+ ?a ?b)" => "(+ ?b ?a)"),
+        rw!("assoc-add"; "(+ ?a (+ ?b ?c))" => "(+ (+ ?a ?b) ?c)"),
+    ],
+    runner = Runner::default()
+        .with_iter_limit(7)
+        .with_scheduler(SimpleScheduler),
+    "(+ 1 (+ 2 (+ 3 (+ 4 (+ 5 (+ 6 7))))))"
+    =>
+    "(+ 7 (+ 6 (+ 5 (+ 4 (+ 3 (+ 2 1))))))"
+    @check |r: Runner<Math, ()>| assert_eq!(r.egraph.number_of_classes(), 127),
+    @existence true
+}
+
+egg::test_fn! {
+    #[should_panic(expected = "Could not prove goal 0")]
+    existence_fail, rules(),
+    "(+ x y)" => "(/ x y)",
+    @existence true
+}
+
+egg::test_fn! {existence_simplify_add, rules(), "(+ x (+ x (+ x x)))" => "(* 4 x)", @existence true }
+egg::test_fn! {existence_powers, rules(), "(* (pow 2 x) (pow 2 y))" => "(pow 2 (+ x y))", @existence true}
+
+egg::test_fn! {
+    existence_simplify_const, rules(),
+    "(+ 1 (- a (* (- 2 1) a)))" => "1",
+    @existence true
+}
+
+egg::test_fn! {
+    existence_simplify_factor, rules(),
+    "(* (+ x 3) (+ x 1))"
+    =>
+    "(+ (+ (* x x) (* 4 x)) 3)"
+    @existence true
+}
+
+egg::test_fn! {existence_diff_same, rules(), "(d x x)" => "1", @existence true}
+egg::test_fn! {existence_diff_different, rules(), "(d x y)" => "0", @existence true}
+egg::test_fn! {existence_diff_simple2,   rules(), "(d x (+ 1 (* y x)))" => "y", @existence true}
+egg::test_fn! {existence_diff_ln,        rules(), "(d x (ln x))" => "(/ 1 x)", @existence true}
+
+egg::test_fn! {
+    existence_diff_power_simple, rules(),
+    "(d x (pow x 3))" => "(* 3 (pow x 2))",
+    @existence true
+}
+
+egg::test_fn! {
+    existence_integ_one, rules(), "(i 1 x)" => "x",
+    @existence true
+}
+
+egg::test_fn! {
+    existence_integ_sin, rules(), "(i (cos x) x)" => "(sin x)", @existence true
+}
+
+egg::test_fn! {
+    existence_integ_x, rules(), "(i (pow x 1) x)" => "(/ (pow x 2) 2)", @existence true
+}
+
+egg::test_fn! {
+    existence_integ_part1, rules(), "(i (* x (cos x)) x)" => "(+ (* x (sin x)) (cos x))", @existence true
+}


### PR DESCRIPTION
This PR refactors explanations and existance proofs to prevent them running into contradictions.
The main change is to phase the instantiations of the LHS of rules with the actual application of those rules. This allows the `memo` to remain up-to-date, and keeps a consistent view of the egraph for that iteration.

The API for appliers has changed slightly. In explanations mode, the applier is given a particular term for the left hand side of the rewrite instead of an eclass id. This elegantly solves the phasing problem.