### PR TITLE
Replace `fxhash` with `rustc-hash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.9.5"
 
 [dependencies]
 env_logger = { version = "0.9.0", default-features = false }
-fxhash = "0.2.1"
+rustc-hash = "2.0.0"
 hashbrown = "0.12.1"
 indexmap = "1.8.1"
 quanta = "0.12"

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -57,7 +57,7 @@ use crate::*;
 /// // This is the search method from the Searcher trait
 /// let matches = same_add.search(&egraph);
 /// let matched_eclasses: Vec<Id> = matches.iter().map(|m| m.eclass).collect();
-/// assert_eq!(matched_eclasses, vec![a11, a22]);
+/// assert_eq!(matched_eclasses, vec![a22, a11]);
 /// ```
 ///
 /// [`FromStr`]: std::str::FromStr

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ use symbolic_expressions::Sexp;
 use fmt::{Debug, Display, Formatter};
 
 #[cfg(feature = "serde-1")]
-use ::serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[allow(unused_imports)]
 use crate::*;
@@ -42,7 +42,7 @@ use crate::*;
 ///
 pub use symbol_table::GlobalSymbol as Symbol;
 
-pub(crate) type BuildHasher = fxhash::FxBuildHasher;
+pub(crate) type BuildHasher = rustc_hash::FxBuildHasher;
 
 // pub(crate) type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasher>;
 // pub(crate) type HashSet<K> = hashbrown::HashSet<K, BuildHasher>;

--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -1,5 +1,5 @@
 use egg::{rewrite as rw, *};
-use fxhash::FxHashSet as HashSet;
+use rustc_hash::FxHashSet as HashSet;
 
 define_language! {
     enum Lambda {


### PR DESCRIPTION
This replaces `fxhash` with [rust-lang/rustc-hash](https://github.com/rust-lang/rustc-hash), which is actively maintained by the rust compiler team.

The changes in the doc test were due to the hash algorithm change. This resulted in order changes within an equality class, which does not affect the overall functionality.

Related discussion: https://github.com/cbreeden/fxhash/issues/10