### PR TITLE
Fix proof OOM by actually counting all neighbors

### DIFF
--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1619,8 +1619,8 @@ impl<'x, L: Language> ExplainNodes<'x, L> {
                     for other in others.iter() {
                         congruence_neighbors[usize::from(*enode)].push(*other);
                         congruence_neighbors[usize::from(*other)].push(*enode);
+                        counter += 1;
                     }
-                    counter += 1;
                     others.push(*enode);
                 } else {
                     counter += 1;


### PR DESCRIPTION
This PR fixes the root cause behind herbie-fp/herbie#1084. Basically, Herbie will sometimes build a truly _enormous_ egraph. The proofs code is supposed to early-exit in cases like this but it doesn't due to a bug. I don't really understand the bug, @oflatt helped on fixing it, but it takes memory usage on this benchmark from about ~24GB to about 0.