### PR TITLE
fix(security): update hashbrown dependency to 0.15.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ version = "0.9.5"
 [dependencies]
 env_logger = { version = "0.9.0", default-features = false }
 fxhash = "0.2.1"
-hashbrown = "0.12.1"
-indexmap = "1.8.1"
+hashbrown = "0.15.2"
+indexmap = "2.7.0"
 quanta = "0.12"
 log = "0.4.17"
 smallvec = { version = "1.8.0", features = ["union", "const_generics"] }
-symbol_table = { version = "0.2.0", features = ["global"] }
+symbol_table = { version = "0.4.0", features = ["global"] }
 symbolic_expressions = "5.0.3"
 thiserror = "1.0.31"
 num-bigint = "0.4"
@@ -45,7 +45,7 @@ lp = ["coin_cbc"]
 reports = ["serde-1", "serde_json"]
 serde-1 = [
   "serde",
-  "indexmap/serde-1",
+  "indexmap/serde",
   "hashbrown/serde",
   "symbol_table/serde",
   "vectorize",

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -136,11 +136,14 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     /// Returns an iterator over the eclasses that contain a given op.
-    pub fn classes_for_op(
+    pub fn classes_for_op<Q>(
         &self,
-        op: &L::Discriminant,
-    ) -> Option<impl ExactSizeIterator<Item = Id> + '_> {
-        self.classes_by_op.get(&op).map(|s| s.iter().copied())
+        op: &Q,
+    ) -> Option<impl ExactSizeIterator<Item = Id> + '_> 
+    where
+        Q: indexmap::Equivalent<L::Discriminant> + core::hash::Hash,
+    {
+        self.classes_by_op.get(op).map(|s| s.iter().copied())
     }
 
     /// Exposes the actual nodes in the egraph.

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -136,10 +136,10 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     /// Returns an iterator over the eclasses that contain a given op.
-    pub fn classes_for_op<Q>(&self, op: &Q) -> Option<impl ExactSizeIterator<Item = Id> + '_>
-    where
-        Q: indexmap::Equivalent<L::Discriminant> + core::hash::Hash,
-    {
+    pub fn classes_for_op(
+        &self,
+        op: &L::Discriminant,
+    ) -> Option<impl ExactSizeIterator<Item = Id> + '_> {
         self.classes_by_op.get(op).map(|s| s.iter().copied())
     }
 

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -136,10 +136,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
     }
 
     /// Returns an iterator over the eclasses that contain a given op.
-    pub fn classes_for_op<Q>(
-        &self,
-        op: &Q,
-    ) -> Option<impl ExactSizeIterator<Item = Id> + '_> 
+    pub fn classes_for_op<Q>(&self, op: &Q) -> Option<impl ExactSizeIterator<Item = Id> + '_>
     where
         Q: indexmap::Equivalent<L::Discriminant> + core::hash::Hash,
     {

--- a/src/language.rs
+++ b/src/language.rs
@@ -32,7 +32,7 @@ pub trait Language: Debug + Clone + Eq + Ord + Hash {
     /// Type representing the cases of this language.
     ///
     /// Used for short-circuiting the search for equivalent nodes.
-    type Discriminant: Debug + Clone + Eq + Hash;
+    type Discriminant: Debug + Clone + Eq + Hash;    
 
     /// Return the `Discriminant` of this node.
     #[allow(enum_intrinsics_non_enums)]

--- a/src/language.rs
+++ b/src/language.rs
@@ -32,7 +32,7 @@ pub trait Language: Debug + Clone + Eq + Ord + Hash {
     /// Type representing the cases of this language.
     ///
     /// Used for short-circuiting the search for equivalent nodes.
-    type Discriminant: Debug + Clone + Eq + Hash;    
+    type Discriminant: Debug + Clone + Eq + Hash;
 
     /// Return the `Discriminant` of this node.
     #[allow(enum_intrinsics_non_enums)]


### PR DESCRIPTION
In Microsoft we recently got a security notification due to usage of hashbrown below 0.15.1
The borsh serialization of the HashMap did not follow the borsh specification. It potentially produced non-canonical encodings dependent on insertion order. It also did not perform canonicty checks on decoding.

This can result in consensus splits and cause equivalent objects to be considered distinct.

This was patched in 0.15.1.