### PR TITLE
Change analysis make function to also take the Id of the created class.

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -1037,7 +1037,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
         let class = EClass {
             id,
             nodes: vec![enode.clone()],
-            data: N::make(self, &original),
+            data: N::make(self, &original, &id),
             parents: Default::default(),
         };
 
@@ -1345,7 +1345,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
             while let Some(class_id) = self.analysis_pending.pop() {
                 let node = self.nodes[usize::from(class_id)].clone();
                 let class_id = self.find_mut(class_id);
-                let node_data = N::make(self, &node);
+                let node_data = N::make(self, &node, &class_id);
                 let class = self.classes.get_mut(&class_id).unwrap();
 
                 let did_merge = self.analysis.merge(&mut class.data, node_data);

--- a/src/language.rs
+++ b/src/language.rs
@@ -795,7 +795,7 @@ pub trait Analysis<L: Language>: Sized {
     /// Doing so will create an infinite loop.
     ///
     /// Note that `enode`'s children may not be canonical
-    fn make(egraph: &mut EGraph<L, Self>, enode: &L) -> Self::Data;
+    fn make(egraph: &mut EGraph<L, Self>, enode: &L, id: &Id) -> Self::Data;
 
     /// An optional hook that allows inspection before a [`union`] occurs.
     /// When explanations are enabled, it gives two ids that represent the two particular terms being unioned, not the canonical ids for the two eclasses.
@@ -862,7 +862,7 @@ pub trait Analysis<L: Language>: Sized {
 
 impl<L: Language> Analysis<L> for () {
     type Data = ();
-    fn make(_egraph: &mut EGraph<L, Self>, _enode: &L) -> Self::Data {}
+    fn make(_egraph: &mut EGraph<L, Self>, _enode: &L, _id: &Id) -> Self::Data {}
     fn merge(&mut self, _: &mut Self::Data, _: Self::Data) -> DidMerge {
         DidMerge(false, false)
     }

--- a/tests/lambda.rs
+++ b/tests/lambda.rs
@@ -75,7 +75,7 @@ impl Analysis<Lambda> for LambdaAnalysis {
         })
     }
 
-    fn make(egraph: &mut EGraph, enode: &Lambda) -> Data {
+    fn make(egraph: &mut EGraph, enode: &Lambda, _id: &Id) -> Data {
         let f = |i: &Id| egraph[*i].data.free.iter().cloned();
         let mut free = HashSet::default();
         match enode {

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -50,7 +50,7 @@ pub struct ConstantFold;
 impl Analysis<Math> for ConstantFold {
     type Data = Option<(Constant, PatternAst<Math>)>;
 
-    fn make(egraph: &mut EGraph, enode: &Math) -> Self::Data {
+    fn make(egraph: &mut EGraph, enode: &Math, _id: &Id) -> Self::Data {
         let x = |i: &Id| egraph[*i].data.as_ref().map(|d| d.0);
         Some(match enode {
             Math::Constant(c) => (*c, format!("{}", c).parse().unwrap()),

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -25,7 +25,7 @@ impl Analysis<Prop> for ConstantFold {
         })
     }
 
-    fn make(egraph: &mut EGraph, enode: &Prop) -> Self::Data {
+    fn make(egraph: &mut EGraph, enode: &Prop, _id: &Id) -> Self::Data {
         let x = |i: &Id| egraph[*i].data.as_ref().map(|c| c.0);
         let result = match enode {
             Prop::Bool(c) => Some((*c, c.to_string().parse().unwrap())),


### PR DESCRIPTION
I have added the Id of the newly created class on calls of analysis make. This allows users to also process the Id in make, where previously the node would not yet return its class when calling egraph.lookup(node) during make.  