### PR TITLE
Migrate LpExtract to `good_lp` to support many ILP solvers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ symbolic_expressions = "5.0.3"
 thiserror = "1.0.31"
 
 # for the lp feature
-coin_cbc = {version = "0.1.6", optional = true}
+good_lp = { version = "1", optional = true }
 
 # for the serde-1 feature
 serde = {version = "1.0.137", features = ["derive"], optional = true}
@@ -41,7 +41,7 @@ ordered-float = "3.0.0"
 [features]
 # forces the use of indexmaps over hashmaps
 deterministic = []
-lp = ["coin_cbc"]
+lp = ["good_lp"]
 reports = ["serde-1", "serde_json"]
 serde-1 = [
   "serde",

--- a/src/lp_extract.rs
+++ b/src/lp_extract.rs
@@ -137,7 +137,7 @@ where
             }
         }
 
-        dbg!(max_order);
+        log::debug!("max_order = {max_order}");
 
         Self {
             egraph,

--- a/src/lp_extract.rs
+++ b/src/lp_extract.rs
@@ -202,7 +202,11 @@ where
             }
         }
 
-        let root_idxs = roots.iter().map(|root| ids[root]).collect();
+        let root_idxs = roots
+            .iter()
+            .map(|id| self.egraph.find(*id))
+            .map(|root| ids[&root])
+            .collect();
 
         assert!(expr.is_dag(), "LpExtract found a cyclic term!: {:?}", expr);
         (expr, root_idxs)
@@ -262,5 +266,23 @@ mod tests {
         println!("{}", exp);
         assert_eq!(exp.len(), 4);
         assert_eq!(ids.len(), 2);
+    }
+
+    #[test]
+    fn extract_root_mismatch() {
+        let mut egraph = EGraph::<S, ()>::default();
+        let a = egraph.add(S::leaf("a"));
+        let b = egraph.add(S::leaf("b"));
+        let plus1 = egraph.add(S::new("+", vec![a, b]));
+        let plus2 = egraph.add(S::new("+", vec![b, a]));
+        egraph.union(plus1, plus2);
+
+        let mut ext = LpExtractor::new(&egraph, AstSize);
+        ext.timeout(10.0); // way too much time
+        let (exp, ids) = ext.solve_multiple(&[plus2]);
+        println!("{:?}", exp);
+        println!("{}", exp);
+        assert_eq!(exp.len(), 3);
+        assert_eq!(ids.len(), 1);
     }
 }


### PR DESCRIPTION
Conveniently, the default solver in `good_lp` is `coin_cbc`, so nothing changes unless a different backend is chosen.

Two interesting solvers this enables are

- [**HiGHS**](https://docs.rs/microlp/latest/microlp/) which has excellent performance and does not require installing anything.
- [**microlp**](https://docs.rs/microlp/latest/microlp/) which is rust-native and can compile to webassembly.

This PR also includes the commits from #355, so you may want to merge that first.