### PR TITLE
Add From<Symbol> implementation for Var

### DIFF
--- a/src/subst.rs
+++ b/src/subst.rs
@@ -94,6 +94,12 @@ impl From<u32> for Var {
     }
 }
 
+impl From<Symbol> for Var {
+    fn from(sym: Symbol) -> Self {
+        Var(VarInner::Sym(sym))
+    }
+}
+
 /// A substitution mapping [`Var`]s to eclass [`Id`]s.
 ///
 #[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
There is currently no way to create your own domain-specific variables that interop with egg's engine. This PR aims to fix that by adding a `From<Symbol>` implementation for `Var`.

This enables custom parsers for patterns that define the string representation of a variable, for example many algebra systems use uppercase letters (e.g. `X + Y -> Y + X`) to denote their variables. Currently egg only supports variables with a question mark prefix (e.g. `?x`, `?#1`).

The only problem I can see this change creating is that it's no longer guaranteed that any variables used by egg have a `?` prefix, but I don't think the code relies on this anywhere.